### PR TITLE
Fix for "grails package" when using your plugin in a Grails 2.3.1 or 2.3.2 project

### DIFF
--- a/scripts/_AssetCompile.groovy
+++ b/scripts/_AssetCompile.groovy
@@ -5,7 +5,6 @@ import org.codehaus.groovy.grails.commons.ApplicationHolder
 includeTargets << grailsScript("_PackagePlugins")
 includeTargets << grailsScript("_GrailsBootstrap")
 
-
 target(assetClean: "Cleans Compiled Assets Directory") {
 	// Clear compiled assets folder
   def assetDir = new File("target/assets")


### PR DESCRIPTION
Dear David,

I'm using Grails 2.3.2 and also your lovely plugin.
However, when I run "grails package" for my own project, I get an error like this;

| Error Error loading event script from file [/Users/sv/.grails/2.3.2/projects/internal-common-ui-plugin/plugins/asset-pipeline-1.1.0/scripts/_Events.groovy] No such property: projectPackager for class: _GrailsBootstrap_groovy (Use --stacktrace to see the full trace)

So, the "projectPackager" is missing... I think it's somehow not being called by the lifecycle.

Anyway, I investigated and I believe found a fix. As you can see it's a simple one line change.
That fixed the problem for me. 

I've tested on both a web project and a plugin project, on Grails 2.3.1 and 2.3.2 and have seen no I'll effects of my change. However, I'm not 100% sure about the plugin lifecycle, so you may have a safer idea for a fix than I do.

Best regards,

Sebastian
