### PR TITLE
Issue #64: assetPathExists renders the body and it can be used in boolean context

### DIFF
--- a/grails-app/taglib/asset/pipeline/AssetsTagLib.groovy
+++ b/grails-app/taglib/asset/pipeline/AssetsTagLib.groovy
@@ -128,13 +128,13 @@ class AssetsTagLib {
 
 	def assetPathExists = { attrs, body ->
 		def src = attrs.remove('src')
-		println "Checking if ${src} exists"
-		if(isAssetPath(src)) {
-			if(body) {
-				out << body
-			}
-		}
-	}
+		def exists = isAssetPath(src)
+            if (exists){
+                out << (body() ?: true)
+            } else {
+                out << ''
+            } 
+    }
 
 	def isAssetPath(src) {
 		def conf = grailsApplication.config.grails.assets

--- a/test/unit/asset/pipeline/AssetsTagLibSpec.groovy
+++ b/test/unit/asset/pipeline/AssetsTagLibSpec.groovy
@@ -115,7 +115,31 @@ class AssetsTagLibSpec extends Specification {
       def fileUri = "asset-pipeline/test/test.css"
       grailsApplication.config.grails.assets.precompiled = false
     expect:
-      tagLib.assetPathExists([src: fileUri], 'true') != ''
+      tagLib.assetPathExists([src: fileUri])
+  }
+  
+  void "test if asset path is missing in dev mode"() {
+    given:
+      def fileUri = "asset-pipeline/test/missing.css"
+      grailsApplication.config.grails.assets.precompiled = false
+    expect:
+      !tagLib.assetPathExists([src: fileUri]) 
+  }
+  
+  void "test if asset path exists in dev mode and closure renders the body"() {
+    given:
+      def fileUri = "asset-pipeline/test/test.css"
+      grailsApplication.config.grails.assets.precompiled = false
+    expect:
+      applyTemplate( "<asset:assetPathExists src=\"$fileUri\">text to render</asset:assetPathExists>" ) == 'text to render'
+  }
+  
+  void "test if asset path is missing in dev mode and closure doesn't render the body"() {
+    given:
+      def fileUri = "asset-pipeline/test/missing.css"
+      grailsApplication.config.grails.assets.precompiled = false
+    expect:
+      applyTemplate( "<asset:assetPathExists src=\"$fileUri\">text to render</asset:assetPathExists>" ) == ''
   }
 
   void "test if asset path exists in prod mode"() {
@@ -127,7 +151,7 @@ class AssetsTagLibSpec extends Specification {
       grailsApplication.config.grails.assets.precompiled = false
       grailsApplication.config.grails.assets.manifest = manifestProperties
     expect:
-      tagLib.assetPathExists([src: fileUri], 'true') != ''
+      tagLib.assetPathExists([src: fileUri])
   }
 
   void "asset path should not exist in dev mode"() {
@@ -135,7 +159,7 @@ class AssetsTagLibSpec extends Specification {
       def fileUri = "asset-pipeline/test/notfound.css"
       grailsApplication.config.grails.assets.precompiled = false
     expect:
-      tagLib.assetPathExists([src: fileUri], 'true') == ''
+      !tagLib.assetPathExists([src: fileUri])
   }
 
   void "should render deferred scripts"() {


### PR DESCRIPTION
The previous test cases were successful, but the body rendered by the tag was wrong.
