### PR TITLE
Deferred scripts that have nested taglibs in them don't render

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ test/dummy/web-app/target
 cobertura.ser
 *.idea/**
 *.iml
+*.ipr
+*.iws

--- a/grails-app/taglib/asset/pipeline/AssetsTagLib.groovy
+++ b/grails-app/taglib/asset/pipeline/AssetsTagLib.groovy
@@ -109,7 +109,7 @@ class AssetsTagLib {
 		if(!assetBlocks) {
 			assetBlocks = []
 		}
-		assetBlocks << [attrs: attrs, body: body]
+		assetBlocks << [attrs: attrs, body: body()]
 		request.setAttribute('assetScriptBlocks', assetBlocks)
 	}
 

--- a/test/unit/asset/pipeline/AssetsTagLibSpec.groovy
+++ b/test/unit/asset/pipeline/AssetsTagLibSpec.groovy
@@ -18,7 +18,6 @@ package asset.pipeline
 
 import grails.test.mixin.TestFor
 import spock.lang.Specification
-import grails.util.Environment
 
 /**
  * @author David Estes
@@ -166,10 +165,20 @@ class AssetsTagLibSpec extends Specification {
     given:
       def script1 = "console.log('hello world 1');"
       def script2 = "console.log('hello world 2');"
+
     when:
-      tagLib.script([type:'text/javascript'], script1)
-      tagLib.script([type:'text/javascript'], script2)
+      applyTemplate("<asset:script type='text/javascript'>$script1</asset:script>")
+      applyTemplate("<asset:script type='text/javascript'>$script2</asset:script>")
+
     then:
-      tagLib.deferredScripts() == "<script type=\"text/javascript\">${script1}</script><script type=\"text/javascript\">${script2}</script>"
+      applyTemplate("<asset:deferredScripts/>") == "<script type=\"text/javascript\">${script1}</script><script type=\"text/javascript\">${script2}</script>"
+  }
+
+  void "should render deferred scripts and evaluate nested groovy expressions"() {
+    when:
+      applyTemplate('<asset:script type="text/javascript"><g:if test="${isTrue}">alert("foo");</g:if></asset:script>', [isTrue: true])
+
+    then:
+      applyTemplate("<asset:deferredScripts/>") == '<script type="text/javascript">alert("foo");</script>'
   }
 }


### PR DESCRIPTION
This patch fixes an issue in the current `<asset:script>` tag that causes it to emits empty `<script></script>` tags if the body of the deferred script has any groovy expressions or nested tag lib calls in it.

This works:

```
<asset:script>console.log("hello world");</asset:script>
...
<asset:deferredScripts/>
```

This doesn't:

```
<asset:script><g:if test="true">console.log("hello world");</g:if></asset:script>
...
<asset:deferredScripts/>
```

This is because for the simple case, grails returns an object type that has a `toString` method on it that does what you'd expect it to.

For the more complex, nested ones, it returns some sort of closure that needs to be evaluated to get the string value.

The attached patch fixes this issue (and has supporting tests) and works for both cases.
