### PR TITLE
Fix erroneous required attribute

### DIFF
--- a/grails-app/taglib/asset/pipeline/AssetsTagLib.groovy
+++ b/grails-app/taglib/asset/pipeline/AssetsTagLib.groovy
@@ -49,7 +49,7 @@ class AssetsTagLib {
 	}
 
 	/**
-	 * @attr href REQUIRED
+	 * @attr href OPTIONAL alternative to src
 	 * @attr src OPTIONAL alternative to href
 	 */
 	def stylesheet = { attrs ->


### PR DESCRIPTION
The attribute 'href' is marked as required but you can use 'src' or 'href' interchangeably. As a result of this issue, I'm getting an inspection error in the default main.gsp layout on this line:

`<asset:stylesheet src="application.css"/>`
