### PR TITLE
Delete the compiled assets as part of the grails clean target

### DIFF
--- a/scripts/_Events.groovy
+++ b/scripts/_Events.groovy
@@ -12,3 +12,7 @@ eventCreateWarStart = {warName, stagingDir ->
 		fileset dir:assetCompileDir
 	}
 }
+
+eventCleanStart = {
+    Ant.delete('dir':'target/assets')
+}


### PR DESCRIPTION
It seems appropriate to clean the compiled assets as part of the grails clean target.  We had an issue where we modified configuration settings to go between minified and non-minified assets, but took us a while to figure out that the target/assets directory had old code in there that was still being deployed, even though we had been calling grails clean.
