### PR TITLE
include configuration settings when generating file cache hash

### DIFF
--- a/src/groovy/asset/pipeline/AssetHelper.groovy
+++ b/src/groovy/asset/pipeline/AssetHelper.groovy
@@ -270,11 +270,30 @@ class AssetHelper {
         AssetHelper.assetFileClasses().findAll { (it.contentType instanceof String) ? it.contentType == contentType : contentType in it.contentType }
     }
 
-    static getByteDigest(fileBytes) {
-        // Generate Checksum
+    static getByteDigest(byte[] fileBytes) {
+        // Generate Checksum based on the file contents and the configuration settings
         MessageDigest md = MessageDigest.getInstance("MD5")
-        md.update(fileBytes)
+        byte[] configBytes = Holders.config.grails.assets.toString().bytes
+        md.update(concat(fileBytes, configBytes))
         def checksum = md.digest()
         return checksum.encodeHex().toString()
+    }
+
+    /**
+     * Concatenate multiple byte arrays
+     * @param arrays
+     * @return an array containing the values of all the arrays
+     */
+    static byte[] concat(byte[]... arrays) {
+        int totalLength = arrays.inject(0, { total, array  -> total + array.length }) as int
+        byte[] result = new byte[totalLength]
+
+        // copy the source arrays into the result array
+        arrays.inject(0, { int currentIndex, byte[] array ->
+            System.arraycopy(array, 0, result, currentIndex, array.length)
+            currentIndex + array.length
+        })
+
+        return result
     }
 }

--- a/test/integration/asset/pipeline/processors/CssProcessorSpec.groovy
+++ b/test/integration/asset/pipeline/processors/CssProcessorSpec.groovy
@@ -18,6 +18,7 @@ package asset.pipeline.processors
 
 import grails.test.spock.IntegrationSpec
 import asset.pipeline.*
+import grails.util.Holders
 
 class CssProcessorSpec extends IntegrationSpec {
     def "replaces image urls with relative paths"() {
@@ -38,9 +39,12 @@ class CssProcessorSpec extends IntegrationSpec {
             def cssProcessor = new CssProcessor(true)
             def file = new File("grails-app/assets/stylesheets/asset-pipeline/test/test.css")
             def assetFile    = new CssAssetFile(file: file)
+            Holders.metaClass.static.getConfig = { ->
+                [grails: [assets: [[minifyJs: true]]]]
+            }
         when:
             def processedCss = cssProcessor.process(assetFile.file.text, assetFile)
         then:
-            processedCss.contains("url('../../grails_logo-eabe4af98753b0163266d7e68bbd32e3.png')")
+            processedCss.contains("url('../../grails_logo-544aa48b9c2f9b532fe57ed0451c9e6e.png')")
     }
 }

--- a/test/unit/asset/pipeline/AssetHelperSpec.groovy
+++ b/test/unit/asset/pipeline/AssetHelperSpec.groovy
@@ -16,23 +16,32 @@
 
 package asset.pipeline
 
-import grails.test.mixin.TestFor
+import grails.util.Holders
 import spock.lang.Specification
 
 /**
  * @author David Estes
  */
 class AssetHelperSpec extends Specification {
-	
-    void "should get byte digest"() {
-     	given:
-	     	def sampleText = "Sample Text"
-	     	def md5Sum
-     	when: 
-     		md5Sum = AssetHelper.getByteDigest(sampleText.bytes)
- 		then:
- 			md5Sum == '83936a3f80ba44c78c9911f5445f2994'
 
+    void "should get byte digest based on file contents and config settings"() {
+        given:
+            Holders.metaClass.static.getConfig = { ->
+                [grails: [assets: [[minifyJs: true]]]]
+            }
+            def sampleText = "Sample Text"
+            def md5Sum
+        when:
+            md5Sum = AssetHelper.getByteDigest(sampleText.bytes)
+        then:
+            md5Sum == '5a15e5d8bb4e8f08c4d76e72894491c6'
+        when:
+            Holders.metaClass.static.getConfig = { ->
+                [grails: [assets: [[minifyJs: false]]]]
+            }
+            md5Sum = AssetHelper.getByteDigest(sampleText.bytes)
+        then:
+            md5Sum == '40901b0561d538750b3da0a7371fb6a2'
     }
 
 


### PR DESCRIPTION
We had an issue where we had some non-minimizable angular code, and had already compiled/deployed it.      We adjusted the minify settings to not mangle method parameter names.  The compiled assets were fixed, but they had the same hash as the old compiled files, so browsers didn't load up the corrected files.

This change factors in the assets configuration into the file hash generation so that if the config changes, it will generate a different hash even if the source file hasn't changed.

The `byte[] concat` method is generic, so it could go into some other utility method (or is there a library for this already available?).

I considered caching the `configBytes`, but the current implementation didn't add any time in our project (it was 19 seconds to compile all our project's assets before and after this change).
