### PR TITLE
Add ability to define multiple dependent files in a single directive...

### DIFF
--- a/grails-app/assets/javascripts/asset-pipeline/test/test_multiple_file_directive.js
+++ b/grails-app/assets/javascripts/asset-pipeline/test/test_multiple_file_directive.js
@@ -1,0 +1,3 @@
+//=require asset-pipeline/test/libs/file_a,asset-pipeline/test/libs/subset/subset_a,asset-pipeline/test/libs/file_b
+
+console.log("Initial Testing Stack for dependency load order");

--- a/src/groovy/asset/pipeline/DirectiveProcessor.groovy
+++ b/src/groovy/asset/pipeline/DirectiveProcessor.groovy
@@ -210,25 +210,37 @@ class DirectiveProcessor {
 
     def requireFileDirective(command, file, tree) {
         def fileName = command[1]
-        def newFile
-        if(fileName.startsWith(AssetHelper.DIRECTIVE_FILE_SEPARATOR)) {
-            newFile = AssetHelper.fileForUri(fileName, this.contentType, null, this.baseFile)
-        } else {
-            def relativeFileName = [relativePath(file.file),fileName].join(AssetHelper.DIRECTIVE_FILE_SEPARATOR)
-            // println "Including Relative File: ${relativeFileName} - ${fileName}"
-            newFile = AssetHelper.fileForUri(relativeFileName, this.contentType, null, this.baseFile)
-        }
 
-        if(newFile) {
-            if(!isFileInTree(newFile,tree)) {
-                // println("Inserting File")
-                tree.tree << getDependencyTree(newFile)
+        List fileNameList = fileName.tokenize(',')
+        if( fileNameList.size() > 1 ) {
+            fileNameList.each{ thisListItem ->
+                requireFileDirective( [ command[0], thisListItem ], file, tree )
             }
-        } else if(!fileName.startsWith(AssetHelper.DIRECTIVE_FILE_SEPARATOR)) {
-            command[1] = AssetHelper.DIRECTIVE_FILE_SEPARATOR + command[1]
-            requireFileDirective(command,file,tree)
-        } else {
-            log.warn("Unable to Locate Asset: ${command[1]}")
+        }
+        else {
+            def newFile
+            if( fileName.startsWith( AssetHelper.DIRECTIVE_FILE_SEPARATOR ) ) {
+                newFile = AssetHelper.fileForUri( fileName, this.contentType, null, this.baseFile )
+            }
+            else {
+                def relativeFileName = [ relativePath( file.file ), fileName ].join( AssetHelper.DIRECTIVE_FILE_SEPARATOR )
+                // println "Including Relative File: ${relativeFileName} - ${fileName}"
+                newFile = AssetHelper.fileForUri( relativeFileName, this.contentType, null, this.baseFile )
+            }
+
+            if( newFile ) {
+                if( !isFileInTree( newFile, tree ) ) {
+                    // println("Inserting File")
+                    tree.tree << getDependencyTree( newFile )
+                }
+            }
+            else if( !fileName.startsWith( AssetHelper.DIRECTIVE_FILE_SEPARATOR ) ) {
+                command[ 1 ] = AssetHelper.DIRECTIVE_FILE_SEPARATOR + command[ 1 ]
+                requireFileDirective( command, file, tree )
+            }
+            else {
+                log.warn( "Unable to Locate Asset: ${ command[ 1 ] }" )
+            }
         }
     }
 

--- a/test/integration/asset/pipeline/DirectiveProcessorSpec.groovy
+++ b/test/integration/asset/pipeline/DirectiveProcessorSpec.groovy
@@ -86,4 +86,19 @@ class DirectiveProcessorSpec extends IntegrationSpec {
         then:
             dependencyList.findIndexOf{ it.path == "asset-pipeline/test/libs/file_c.js" } < dependencyList.findIndexOf{ it.path == "asset-pipeline/test/libs/file_b.js"}
     }
+
+    def "gets dependency list order correct when multiple dependencies are defined in one directive"() {
+        given: "A uri and file extension with require directives defining multiple dependencies in one directive"
+            def uri                = "asset-pipeline/test/test_multiple_file_directive.js"
+            def fileExtension      = "js"
+            def contentType        = "application/javascript"
+            def file               = AssetHelper.fileForUri(uri, contentType, fileExtension)
+            def directiveProcessor = new DirectiveProcessor(contentType)
+        when:
+            def dependencyList = directiveProcessor.getFlattenedRequireList(file)
+        then:
+            dependencyList.findIndexOf{ it.path == "asset-pipeline/test/libs/file_a.js" } < dependencyList.findIndexOf{ it.path == "asset-pipeline/test/libs/subset/subset_a.js"}
+            dependencyList.findIndexOf{ it.path == "asset-pipeline/test/libs/subset/subset_a.js" } < dependencyList.findIndexOf{ it.path == "asset-pipeline/test/libs/file_b.js"}
+            dependencyList.findIndexOf{ it.path == "asset-pipeline/test/libs/file_c.js" } < dependencyList.findIndexOf{ it.path == "asset-pipeline/test/libs/file_b.js"}
+    }
 }


### PR DESCRIPTION
...using a comma-delimited string.

Just a bit of background: I'm creating a plugin that will resolve dependencies in Sencha Ext JS applications. Sencha defines its own requires syntax, several ways to specify required classes, and uses class names rather than file names. So a simple regex to match the directive won't suffice. My plugin parses the JS files, determines the required files by matching the class names to file names, and adds them into the tree inside the asset file's directiveForLine().

However, I can't specify the additional files using "require_tree", since it doesn't allow control over the order. And the current way the directive handling works, each individual file directive _must_ be specified on its own line. So there's no way to force more than one file to be added to the tree.

This small change allows a directive to specify multiple files, in order, to be included. The syntax is simple "//= require file1,file2,file3".

I also added a test to ensure that it works without breaking anything else.

Let me know if you have any questions. Thanks for the great work on this plugin!
