### PR TITLE
Absolute path on tree directives

### DIFF
--- a/grails-app/assets/javascripts/asset-pipeline/test/absolute-path/full-tree/full_tree.js
+++ b/grails-app/assets/javascripts/asset-pipeline/test/absolute-path/full-tree/full_tree.js
@@ -1,0 +1,1 @@
+console.log("Full Tree");

--- a/grails-app/assets/javascripts/asset-pipeline/test/absolute-path/test/test_full_tree.js
+++ b/grails-app/assets/javascripts/asset-pipeline/test/absolute-path/test/test_full_tree.js
@@ -1,0 +1,1 @@
+//= require_full_tree asset-pipeline/test/absolute-path/full-tree

--- a/grails-app/assets/javascripts/asset-pipeline/test/absolute-path/test/test_tree.js
+++ b/grails-app/assets/javascripts/asset-pipeline/test/absolute-path/test/test_tree.js
@@ -1,0 +1,1 @@
+//= require_tree asset-pipeline/test/absolute-path/tree

--- a/grails-app/assets/javascripts/asset-pipeline/test/absolute-path/tree/tree.js
+++ b/grails-app/assets/javascripts/asset-pipeline/test/absolute-path/tree/tree.js
@@ -1,0 +1,1 @@
+console.log("Tree");

--- a/src/groovy/asset/pipeline/DirectiveProcessor.groovy
+++ b/src/groovy/asset/pipeline/DirectiveProcessor.groovy
@@ -152,28 +152,53 @@ class DirectiveProcessor {
     }
 
     def requireTreeDirective(command, fileSpec, tree) {
+        String directivePath = command[1]
+
         def parentFile
-        if(!command[1] || command[1] == '.') {
+        if(!directivePath || directivePath == '.') {
             parentFile = new File(fileSpec.file.getParent())
         } else {
-            parentFile = new File([fileSpec.file.getParent(),command[1]].join(File.separator))
+            parentFile = new File([fileSpec.file.getParent(),directivePath].join(File.separator))
         }
-        recursiveTreeAppend(parentFile,tree)
+
+        if(parentFile.exists() && parentFile.isDirectory()) {
+            recursiveTreeAppend(parentFile, tree)
+        }
+        else {
+            def rootPaths = AssetHelper.scopedDirectoryPaths(new File("grails-app/assets").getAbsolutePath())
+
+            rootPaths.each { path ->
+                def absolutePath = new File(path, directivePath)
+
+                if (absolutePath.exists() && absolutePath.isDirectory()) {
+                    recursiveTreeAppend(absolutePath, tree)
+                }
+            }
+        }
     }
 
     def requireFullTreeDirective(command, fileSpec, tree) {
+        String directivePath = command[1]
+
         def parentFile
-        if(!command[1] || command[1] == '.') {
+        if(!directivePath || directivePath == '.') {
             parentFile = new File(fileSpec.file.getParent())
         } else {
-            parentFile = new File([fileSpec.file.getParent(),command[1]].join(File.separator))
+            parentFile = new File([fileSpec.file.getParent(),directivePath].join(File.separator))
         }
+
         def relativeParent = relativePath(parentFile,true)
 
         AssetHelper.getAssetPaths().each { path ->
+
             def parentFileScoped = new File(path, relativeParent)
+            def absolutePath = new File(path, directivePath)
+
             if(parentFileScoped.exists() && parentFileScoped.isDirectory()) {
                 recursiveTreeAppend(parentFileScoped, tree)
+            }
+            else if (absolutePath.exists() && absolutePath.isDirectory()) {
+                recursiveTreeAppend(absolutePath, tree)
             }
         }
     }

--- a/test/integration/asset/pipeline/DirectiveProcessorSpec.groovy
+++ b/test/integration/asset/pipeline/DirectiveProcessorSpec.groovy
@@ -101,4 +101,32 @@ class DirectiveProcessorSpec extends IntegrationSpec {
             dependencyList.findIndexOf{ it.path == "asset-pipeline/test/libs/subset/subset_a.js" } < dependencyList.findIndexOf{ it.path == "asset-pipeline/test/libs/file_b.js"}
             dependencyList.findIndexOf{ it.path == "asset-pipeline/test/libs/file_c.js" } < dependencyList.findIndexOf{ it.path == "asset-pipeline/test/libs/file_b.js"}
     }
+
+    def "gets dependency list where relative paths don't exist but absolute paths do in tree directive"() {
+        given: "A uri and file extension with an absolute path tree require directive"
+            def uri                = "asset-pipeline/test/absolute-path/test/test_tree.js"
+            def fileExtension      = "js"
+            def contentType        = "application/javascript"
+            def file               = AssetHelper.fileForUri(uri, contentType, fileExtension)
+            def directiveProcessor = new DirectiveProcessor(contentType)
+        when:
+            def dependencyList = directiveProcessor.getFlattenedRequireList(file)
+        then:
+            dependencyList.size() == 2
+    }
+
+    def "gets dependency list where relative paths don't exist but absolute paths do in full_tree directive"() {
+        given: "A uri and file extension with an absolute path full_tree require directive"
+            def uri                = "asset-pipeline/test/absolute-path/test/test_full_tree.js"
+            def fileExtension      = "js"
+            def contentType        = "application/javascript"
+            def file               = AssetHelper.fileForUri(uri, contentType, fileExtension)
+            def directiveProcessor = new DirectiveProcessor(contentType)
+        when:
+            def dependencyList = directiveProcessor.getFlattenedRequireList(file)
+        then:
+            dependencyList.size() == 2
+    }
+
+
 }


### PR DESCRIPTION
Have tree and full_tree directives default to absolute paths when a relative one can't be found.
