### PR TITLE
fixes #115, sets original file canonical path on cache if present

### DIFF
--- a/AssetPipelineGrailsPlugin.groovy
+++ b/AssetPipelineGrailsPlugin.groovy
@@ -21,7 +21,7 @@ import asset.pipeline.grails.AssetResourceLocator
 
 
 class AssetPipelineGrailsPlugin {
-    def version         = "1.9.0"
+    def version         = "1.9.1"
     def grailsVersion   = "2.0 > *"
     def title           = "Asset Pipeline Plugin"
     def author          = "David Estes"

--- a/src/groovy/asset/pipeline/AbstractAssetFile.groovy
+++ b/src/groovy/asset/pipeline/AbstractAssetFile.groovy
@@ -17,7 +17,7 @@ abstract class AbstractAssetFile implements AssetFile {
 
 		def md5 = AssetHelper.getByteDigest(fileText.bytes)
 		if(!skipCache) {
-			def cache = CacheManager.findCache(file.canonicalPath, md5,baseFile?.canonicalPath)
+			def cache = CacheManager.findCache(file.canonicalPath, md5, baseFile?.file?.canonicalPath)
 			if(cache) {
 				return cache
 			}
@@ -28,7 +28,7 @@ abstract class AbstractAssetFile implements AssetFile {
 		}
 
 		if(!skipCache) {
-			CacheManager.createCache(file.canonicalPath,md5,fileText, baseFile?.canonicalPath)
+			CacheManager.createCache(file.canonicalPath, md5, fileText, baseFile?.file?.canonicalPath)
 		}
 
 		return fileText

--- a/src/groovy/asset/pipeline/CacheManager.groovy
+++ b/src/groovy/asset/pipeline/CacheManager.groovy
@@ -19,10 +19,10 @@ package asset.pipeline
 class CacheManager {
 	static cache = [:]
 
-	static def findCache(fileName, md5, modifierKey = null) {
+	static def findCache(fileName, md5, originalFileName = null) {
 		def cacheRecord = CacheManager.cache[fileName]
 
-		if(cacheRecord && cacheRecord.md5 == md5 && cacheRecord.modifierKey == modifierKey) {
+		if(cacheRecord && cacheRecord.md5 == md5 && cacheRecord.originalFileName == originalFileName) {
 			def cacheFiles = cacheRecord.dependencies.keySet()
 			def expiredCacheFound = cacheFiles.find { cacheFileName ->
 				def cacheFile = new File(cacheFileName)
@@ -40,24 +40,24 @@ class CacheManager {
 				return null
 			}
 			return cacheRecord.processedFileText
-		} else {
+		} else if (cacheRecord) {
 			CacheManager.cache.remove(fileName)
 			return null
 		}
 	}
 
-	static def createCache(fileName, md5Hash, processedFileText, modifierKey=null) {
+	static def createCache(fileName, md5Hash, processedFileText, originalFileName = null) {
 		def cacheRecord = CacheManager.cache[fileName]
 		if(cacheRecord) {
 			CacheManager.cache[fileName] = cacheRecord + [
 				md5: md5Hash,
-				modifierKey: modifierKey,
+				originalFileName: originalFileName,
 				processedFileText: processedFileText
 			]
 		} else {
 			CacheManager.cache[fileName] = [
 				md5: md5Hash,
-				modifierKey: modifierKey,
+				originalFileName: originalFileName,
 				processedFileText: processedFileText,
 				dependencies: [:]
 			]
@@ -66,7 +66,6 @@ class CacheManager {
 	}
 
 	static def addCacheDependency(fileName, dependentFile) {
-
 		def cacheRecord = CacheManager.cache[fileName]
 		if(!cacheRecord) {
 			CacheManager.createCache(fileName, null, null)

--- a/test/unit/asset/pipeline/CacheManagerSpec.groovy
+++ b/test/unit/asset/pipeline/CacheManagerSpec.groovy
@@ -87,4 +87,25 @@ class CacheManagerSpec extends Specification {
         then:
             cacheContent == null
     }
+
+    void "changing original file should be a cache miss and remove cached item from cache"() {
+        given:
+            def testFile = new File('grails-app/assets/stylesheets/asset-pipeline/test/test.css')
+            def testFileName = testFile.name
+            def testMd5 = AssetHelper.getByteDigest(testFile.bytes)
+
+        when:
+            CacheManager.createCache(testFileName, testMd5, testFile.text, testFile.canonicalPath)
+
+        then:
+            CacheManager.findCache(testFileName, testMd5, testFile.canonicalPath) != null
+            CacheManager.cache[testFileName] != null
+
+        when:
+            boolean cacheMiss = CacheManager.findCache(testFileName, testMd5, "not the same file path") == null
+
+        then:
+            assert cacheMiss
+            CacheManager.cache[testFileName] == null
+    }
 }


### PR DESCRIPTION
This PR fixes #115.  The code was blowing up as it was looking for a `canonicalPath` on an `AssetFile` when I think it was actually looking for the `canonicalPath` on the original file.

I also changed the parameter name to `originalFileName` as I thought that better showed the intent of the variable and didn't see any other uses that it contradicted.

It also adds a test for the cache when the optional parameter is set and ensures that it clears the cache on a cache miss.
