### PR TITLE
Added newline for printing multiple javascript files

### DIFF
--- a/grails-app/taglib/asset/pipeline/AssetsTagLib.groovy
+++ b/grails-app/taglib/asset/pipeline/AssetsTagLib.groovy
@@ -42,7 +42,7 @@ class AssetsTagLib {
 			}
 			list.each { dep ->
 				def depAssetPath = assetPath([src: "${dep.path}", ignorePrefix:true])
-				out << "<script src=\"${depAssetPath}?${modifierParams.join("&")}\" type=\"text/javascript\" ${paramsToHtmlAttr(attrs)}></script>"
+				out << "<script src=\"${depAssetPath}?${modifierParams.join("&")}\" type=\"text/javascript\" ${paramsToHtmlAttr(attrs)}></script>\n"
 			}
 			// println "Fetching Dev Mode Dependency List Time ${new Date().time - startTime}"
 		}

--- a/test/unit/asset/pipeline/AssetsTagLibSpec.groovy
+++ b/test/unit/asset/pipeline/AssetsTagLibSpec.groovy
@@ -64,7 +64,7 @@ class AssetsTagLibSpec extends Specification {
 
     then:
       1 * assetProcessorServiceMock.getDependencyList('asset-pipeline/test/test', 'application/javascript', 'js') >> { [[path: "asset-pipeline/test/test.js"],[path:"asset-pipeline/test/test2.js"]] }
-      output == '<script src="/assets/asset-pipeline/test/test.js?compile=false" type="text/javascript" ></script><script src="/assets/asset-pipeline/test/test2.js?compile=false" type="text/javascript" ></script>'
+      output == '<script src="/assets/asset-pipeline/test/test.js?compile=false" type="text/javascript" ></script>\n<script src="/assets/asset-pipeline/test/test2.js?compile=false" type="text/javascript" ></script>\n'
     
   }
 


### PR DESCRIPTION
I added a newline in debug mode to increase readability when printing many files. Now you don't have to scroll to the right, but instead see them nicely under each other, which makes it easier to debug.
