### PR TITLE
Include link to JSX Asset-Pipeline Plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,4 +29,5 @@ Additional Resources
 * [SASS/SCSS Compass Asset-Pipeline Plugin](http://github.com/bertramdev/sass-grails-asset-pipeline)
 * [Handlebars Asset-Pipeline Plugin](http://github.com/bertramdev/handlebars-grails-asset-pipeline)
 * [Ember Asset-Pipeline Plugin](http://github.com/bertramdev/ember-grails-asset-pipeline)
+* [JSX Asset-Pipeline Plugin] (https://github.com/balsamiq/jsx-grails-asset-pipeline)
 * [Rails Asset Pipeline Guide](http://guides.rubyonrails.org/asset_pipeline.html)


### PR DESCRIPTION
I thought readers might want to know about the JSX Asset-Pipeline plugin I put together a while back. I updated it to react 0.12.0 and asset-pipeline 1.9.9 this morning. If this is not the right place for this please let me know.
