### PR TITLE
An amendment to the content-length header patch

### DIFF
--- a/src/groovy/asset/pipeline/AssetPipelineFilter.groovy
+++ b/src/groovy/asset/pipeline/AssetPipelineFilter.groovy
@@ -46,7 +46,7 @@ class AssetPipelineFilter implements Filter {
                 response.setContentType(format)
                 response.setHeader('Vary', 'Accept-Encoding')
                 response.setHeader('Cache-Control','public, max-age=31536000')
-                response.setContentLength(file.contentLength())
+                response.setHeader('Content-Length', file.contentLength().toString())
 
                 try {
                     response.outputStream << file.inputStream.getBytes()


### PR DESCRIPTION
Probably better to use the generic String type header setter rather than the content length setter which seems to suffer from type differences (long/int) in the signatures across the request mixin hierarchy.
