### PR TITLE
Integrate Asset Pipeline with external tag libs

### DIFF
--- a/grails-app/conf/AssetPipelineBootStrap.groovy
+++ b/grails-app/conf/AssetPipelineBootStrap.groovy
@@ -1,16 +1,30 @@
 import asset.pipeline.AssetPipelineConfigHolder
+import java.util.Map.Entry
 import javax.servlet.ServletContext
+import javax.servlet.http.HttpServletRequest
+import org.codehaus.groovy.grails.plugins.web.taglib.ApplicationTagLib
 import org.springframework.context.ApplicationContext
 import org.springframework.core.io.Resource
+
+import static asset.pipeline.grails.utils.net.HttpServletRequests.getBaseUrlWithScheme
+import static org.codehaus.groovy.grails.web.util.WebUtils.retrieveGrailsWebRequest
 
 
 class AssetPipelineBootStrap {
 
+	private static final int SLASH = (int) '/' as char
+
+
 	def assetProcessorService
 	def grailsApplication
+	def pluginManager
 
 
 	def init = {final ServletContext servletContext ->
+		wrapLinkWriters((Map<String, Closure<String>>) ApplicationTagLib.LINK_WRITERS, '/plugins/')
+		wrapLinkWriters('com.grailsrocks.jqueryui.JqueryUiTagLib',   '/plugins/')
+		wrapLinkWriters('org.grails.plugin.resource.ResourceTagLib', "/${pluginManager.getGrailsPlugin('resources')?.instance?.getUriPrefix(grailsApplication)}/plugins/")
+
 		final ConfigObject conf = grailsApplication.config.grails.assets
 
 		final def storagePath = conf.storagePath
@@ -65,6 +79,56 @@ class AssetPipelineBootStrap {
 
 				manifest.store(new File(storageDir, 'manifest.properties').newWriter(), '')
 			}
+		}
+	}
+
+
+	private void wrapLinkWriters(final String tagLibClassName, final String removeUriPrefix) {
+		final Map<String, Closure<String>> linkWriterByName
+		try {
+			linkWriterByName = (Map<String, Closure<String>>) Class.forName(tagLibClassName).LINK_WRITERS
+		}
+		catch (final Exception ex) {
+			// ignore
+			return
+		}
+		wrapLinkWriters(linkWriterByName, removeUriPrefix)
+		log.debug('Integrated Asset Pipeline with ' + tagLibClassName + ' using URI prefix ' + removeUriPrefix)
+	}
+
+	private void wrapLinkWriters(final Map<String, Closure<String>> linkWriterByName, final String removeUriPrefix) {
+		for (final Entry<String, Closure<String>> linkWriterForName : linkWriterByName.entrySet()) {
+			linkWriterForName.value = wrapLinkWriter(linkWriterForName.value, removeUriPrefix)
+		}
+	}
+
+	private Closure<String> wrapLinkWriter(final Closure<String> linkWriter, final String removeUriPrefix) {
+		{final String url, final Map<String, String> constants, final Map<String, ?> attrs ->
+			final int indexSlash3
+			final int indexAfterSlash3
+			final int indexSlash4
+
+			final String assetUrl =
+				url.startsWith(removeUriPrefix) &&
+				(indexSlash3      = url.indexOf(SLASH, removeUriPrefix.length())) != -1 &&
+				(indexAfterSlash3 = indexSlash3 + 1)                              != url.length() &&
+				(indexSlash4      = url.indexOf(SLASH, indexAfterSlash3))         != -1 \
+					? url.substring(indexSlash4 + 1)
+					: url
+
+			final HttpServletRequest req = retrieveGrailsWebRequest().currentRequest
+
+			final String assetPipelineBaseUrl
+			linkWriter(
+				(
+					assetProcessorService.isAssetPath(assetUrl) &&
+					(assetPipelineBaseUrl = assetProcessorService.getConfigBaseUrl(req)) != null
+						? assetPipelineBaseUrl + assetUrl
+						: getBaseUrlWithScheme(req).append(url).toString()
+				),
+				constants,
+				attrs
+			)
 		}
 	}
 }

--- a/grails-app/conf/BuildConfig.groovy
+++ b/grails-app/conf/BuildConfig.groovy
@@ -24,7 +24,6 @@ grails {
 					// Temporary inclusion due to bug in 2.4.2
 					compile group: 'cglib',                   name: 'cglib-nodep',         version: '2.2.2', {export = false}
 					compile group: 'com.bertramlabs.plugins', name: 'asset-pipeline-core', version: '2.6.0'
-					runtime group: 'org.mozilla',             name: 'rhino',               version: '1.7R4'
 				}
 
 				plugins {

--- a/grails-app/conf/BuildConfig.groovy
+++ b/grails-app/conf/BuildConfig.groovy
@@ -25,9 +25,9 @@ grails {
 				}
 
 				plugins {
-					test    name: 'code-coverage',       version: '1.2.7',  {export = false}
-					build   name: 'release',             version: '3.1.1',  {export = false}
-					build   name: 'rest-client-builder', version: '2.0.1',  {export = false}
+					test    name: 'code-coverage',       version: '2.0.3-3', {export = false}
+					build   name: 'release',             version: '3.1.1',   {export = false}
+					build   name: 'rest-client-builder', version: '2.1.1',   {export = false}
 					compile name: 'webxml',              version: '1.4.1'
 				}
 			}

--- a/grails-app/conf/BuildConfig.groovy
+++ b/grails-app/conf/BuildConfig.groovy
@@ -21,8 +21,6 @@ grails {
 				}
 
 				dependencies {
-					// Temporary inclusion due to bug in 2.4.2
-					compile group: 'cglib',                   name: 'cglib-nodep',         version: '2.2.2', {export = false}
 					compile group: 'com.bertramlabs.plugins', name: 'asset-pipeline-core', version: '2.6.0'
 				}
 


### PR DESCRIPTION
I now integrate Asset Pipeline with external tag libs without adding any new dependencies or plugins.

Additionally, I removed some unnecessary dependencies (cglib-nodep should not be necessary for Grails 2.5.1, and rhino shouldn't be necessary because it is included in asset-pipeline-core).

I also upgraded 2 out-of-date plugins to the current versions for Grails 2.x.

The dependency & plugin cleanup can be split from the external tag lib integration.