### PR TITLE
BuildConfig.groovy cleanup

### DIFF
--- a/grails-app/conf/BuildConfig.groovy
+++ b/grails-app/conf/BuildConfig.groovy
@@ -24,7 +24,6 @@ grails {
 					// Temporary inclusion due to bug in 2.4.2
 					compile group: 'cglib',                   name: 'cglib-nodep',         version: '2.2.2', {export = false}
 					compile group: 'com.bertramlabs.plugins', name: 'asset-pipeline-core', version: '2.6.0'
-					runtime group: 'org.mozilla',             name: 'rhino',               version: '1.7R4'
 				}
 
 				plugins {

--- a/grails-app/conf/BuildConfig.groovy
+++ b/grails-app/conf/BuildConfig.groovy
@@ -25,9 +25,9 @@ grails {
 				}
 
 				plugins {
-					test    name: 'code-coverage',       version: '1.2.7',  {export = false}
-					build   name: 'release',             version: '3.1.1',  {export = false}
-					build   name: 'rest-client-builder', version: '2.0.1',  {export = false}
+					test    name: 'code-coverage',       version: '2.0.3-3', {export = false}
+					build   name: 'release',             version: '3.1.1',   {export = false}
+					build   name: 'rest-client-builder', version: '2.1.1',   {export = false}
 					compile name: 'webxml',              version: '1.4.1'
 				}
 			}

--- a/grails-app/conf/BuildConfig.groovy
+++ b/grails-app/conf/BuildConfig.groovy
@@ -21,8 +21,6 @@ grails {
 				}
 
 				dependencies {
-					// Temporary inclusion due to bug in 2.4.2
-					compile group: 'cglib',                   name: 'cglib-nodep',         version: '2.2.2', {export = false}
 					compile group: 'com.bertramlabs.plugins', name: 'asset-pipeline-core', version: '2.6.0'
 				}
 


### PR DESCRIPTION
`BuildConfig.groovy` cleanup.  This PR is branched from the branch for PR #309, so if you want to accept both, you can either merge #309 first, then this, or you could just close #309 and only accept this, since this includes the #309 changes.

The branch of #304 is now branched from this branch.  It looks like you won't accept #304, but, if you do, the same situation applies there, too.