### PR TITLE
Added grails.assets.useGrailsResourceMethod setting

### DIFF
--- a/src/groovy/asset/pipeline/grails/CachingLinkGenerator.groovy
+++ b/src/groovy/asset/pipeline/grails/CachingLinkGenerator.groovy
@@ -22,7 +22,14 @@ class CachingLinkGenerator extends org.codehaus.groovy.grails.web.mapping.Cachin
 
 	@Override
 	String resource(final Map attrs) {
-		! grailsApplication.config.grails.assets.useGrailsResourceMethod && asset(attrs) ?: super.resource(attrs)
+		if (! grailsApplication.config.grails.assets.useGrailsResourceMethod) {
+			final String url = asset(attrs)
+			if (url) {
+				return url
+			}
+		}
+
+		super.resource(attrs)
 	}
 
 	/**

--- a/src/groovy/asset/pipeline/grails/CachingLinkGenerator.groovy
+++ b/src/groovy/asset/pipeline/grails/CachingLinkGenerator.groovy
@@ -12,6 +12,7 @@ import static org.codehaus.groovy.grails.web.servlet.mvc.GrailsWebRequest.lookup
 class CachingLinkGenerator extends org.codehaus.groovy.grails.web.mapping.CachingLinkGenerator {
 
 	def assetProcessorService
+	def grailsApplication
 
 
 	CachingLinkGenerator(final String serverUrl) {
@@ -21,7 +22,7 @@ class CachingLinkGenerator extends org.codehaus.groovy.grails.web.mapping.Cachin
 
 	@Override
 	String resource(final Map attrs) {
-		asset(attrs) ?: super.resource(attrs)
+		! grailsApplication.config.grails.assets.useGrailsResourceMethod && asset(attrs) ?: super.resource(attrs)
 	}
 
 	/**

--- a/src/groovy/asset/pipeline/grails/LinkGenerator.groovy
+++ b/src/groovy/asset/pipeline/grails/LinkGenerator.groovy
@@ -9,6 +9,7 @@ import org.codehaus.groovy.grails.web.mapping.DefaultLinkGenerator
 class LinkGenerator extends DefaultLinkGenerator {
 
 	def assetProcessorService
+	def grailsApplication
 
 
 	LinkGenerator(final String serverUrl) {
@@ -18,7 +19,7 @@ class LinkGenerator extends DefaultLinkGenerator {
 
 	@Override
 	String resource(final Map attrs) {
-		asset(attrs) ?: super.resource(attrs)
+		! grailsApplication.config.grails.assets.useGrailsResourceMethod && asset(attrs) ?: super.resource(attrs)
 	}
 
 	/**

--- a/src/groovy/asset/pipeline/grails/LinkGenerator.groovy
+++ b/src/groovy/asset/pipeline/grails/LinkGenerator.groovy
@@ -19,7 +19,14 @@ class LinkGenerator extends DefaultLinkGenerator {
 
 	@Override
 	String resource(final Map attrs) {
-		! grailsApplication.config.grails.assets.useGrailsResourceMethod && asset(attrs) ?: super.resource(attrs)
+		if (! grailsApplication.config.grails.assets.useGrailsResourceMethod) {
+			final String url = asset(attrs)
+			if (url) {
+				return url
+			}
+		}
+
+		super.resource(attrs)
 	}
 
 	/**

--- a/test/integration/asset/pipeline/grails/CachingLinkGeneratorSpec.groovy
+++ b/test/integration/asset/pipeline/grails/CachingLinkGeneratorSpec.groovy
@@ -20,6 +20,7 @@ import grails.test.spock.IntegrationSpec
 import asset.pipeline.AssetPipelineConfigHolder
 
 class CachingLinkGeneratorSpec extends IntegrationSpec {
+
     def grailsApplication
     def assetProcessorService
 
@@ -27,6 +28,7 @@ class CachingLinkGeneratorSpec extends IntegrationSpec {
         given: "A LinkGenerator and an image"
             def linkGenerator = new CachingLinkGenerator("http://localhost:8080")
             linkGenerator.assetProcessorService = assetProcessorService
+            linkGenerator.grailsApplication     = grailsApplication
 
             def filePath = "grails_logo.png"
         when:
@@ -39,6 +41,7 @@ class CachingLinkGeneratorSpec extends IntegrationSpec {
         given: "A LinkGenerator and an image"
             def linkGenerator = new CachingLinkGenerator("http://localhost:8080")
             linkGenerator.assetProcessorService = assetProcessorService
+            linkGenerator.grailsApplication     = grailsApplication
 
             def filePath = "grails_logo.png"
         when:
@@ -52,6 +55,8 @@ class CachingLinkGeneratorSpec extends IntegrationSpec {
         given: "A LinkGenerator and an image"
             def linkGenerator = new CachingLinkGenerator("http://localhost:8080")
             linkGenerator.assetProcessorService = assetProcessorService
+            linkGenerator.grailsApplication     = grailsApplication
+
             def filePath = "grails_logo.png"
             Properties manifestProperties = new Properties()
             manifestProperties.setProperty(filePath, "grails_logo-abcdefg.png")
@@ -67,6 +72,7 @@ class CachingLinkGeneratorSpec extends IntegrationSpec {
         given: "A LinkGenerator and an image"
             def linkGenerator = new CachingLinkGenerator("http://localhost:8080")
             linkGenerator.assetProcessorService = assetProcessorService
+            linkGenerator.grailsApplication     = grailsApplication
 
             def filePath = "fake_image.png"
         when:

--- a/test/integration/asset/pipeline/grails/LinkGeneratorSpec.groovy
+++ b/test/integration/asset/pipeline/grails/LinkGeneratorSpec.groovy
@@ -20,15 +20,17 @@ import grails.test.spock.IntegrationSpec
 import asset.pipeline.AssetPipelineConfigHolder
 
 class LinkGeneratorSpec extends IntegrationSpec {
+
     def grailsApplication
     def assetProcessorService
 
     def "finds assets when calling for resource in dev mode"() {
         given: "A LinkGenerator and an image"
-            AssetPipelineConfigHolder.manifest = null
             def linkGenerator = new LinkGenerator("http://localhost:8080")
             linkGenerator.assetProcessorService = assetProcessorService
+            linkGenerator.grailsApplication     = grailsApplication
 
+            AssetPipelineConfigHolder.manifest = null
             def filePath = "grails_logo.png"
         when:
             def resource = linkGenerator.resource(file: filePath)
@@ -39,10 +41,11 @@ class LinkGeneratorSpec extends IntegrationSpec {
 
     def "finds assets with absolute path when calling for resource in dev mode"() {
         given: "A LinkGenerator and an image"
-            AssetPipelineConfigHolder.manifest = null
             def linkGenerator = new LinkGenerator("http://localhost:8080")
             linkGenerator.assetProcessorService = assetProcessorService
+            linkGenerator.grailsApplication     = grailsApplication
 
+            AssetPipelineConfigHolder.manifest = null
             def filePath = "grails_logo.png"
         when:
             def resource = linkGenerator.resource(file: filePath,absolute:true)
@@ -54,6 +57,8 @@ class LinkGeneratorSpec extends IntegrationSpec {
         given: "A LinkGenerator and an image"
             def linkGenerator = new LinkGenerator("http://localhost:8080")
             linkGenerator.assetProcessorService = assetProcessorService
+            linkGenerator.grailsApplication     = grailsApplication
+
             def filePath = "grails_logo.png"
             Properties manifestProperties = new Properties()
             manifestProperties.setProperty(filePath, "grails_logo-abcdefg.png")
@@ -70,6 +75,7 @@ class LinkGeneratorSpec extends IntegrationSpec {
         given: "A LinkGenerator and an image"
             def linkGenerator = new LinkGenerator("http://localhost:8080")
             linkGenerator.assetProcessorService = assetProcessorService
+            linkGenerator.grailsApplication     = grailsApplication
 
             def filePath = "fake_image.png"
         when:


### PR DESCRIPTION
Added `grails.assets.useGrailsResourceMethod` setting to use Grails `resource(...)` instead of AP `asset(...)`.

Useful in the situation where your app is using Resources (not AP), but AP was included by a plugin, so the AP `(Caching)LinkGenerator` replaced the Grails one.

Since AP ignores files under `web-app` in your app, then a similarly named asset from a plugin can be found instead, and that will be used instead of the resource from your app, making the plugin asset take precedence over the app resource, which is very bad.

Even more, `asset(...)` ignores the `dir` attribute used by Resources' `resource(...)`, which means that the exact resource path isn't even used.

This one new setting solves all the problems by allowing you to just use Resources for `resource(...)`.

It's disabled by default, so the current behavior will still be the default behavior after this is merged in.