### PR TITLE
BuildConfig.groovy cleanup

### DIFF
--- a/grails-app/conf/BuildConfig.groovy
+++ b/grails-app/conf/BuildConfig.groovy
@@ -23,14 +23,13 @@ grails {
 				dependencies {
 					// Temporary inclusion due to bug in 2.4.2
 					compile group: 'cglib',                   name: 'cglib-nodep',         version: '2.2.2', {export = false}
-					compile group: 'com.bertramlabs.plugins', name: 'asset-pipeline-core', version: '2.8.0'
-					runtime group: 'org.mozilla',             name: 'rhino',               version: '1.7R4'
+					compile group: 'com.bertramlabs.plugins', name: 'asset-pipeline-core', version: '2.8.2'
 				}
 
 				plugins {
-					test    name: 'code-coverage',       version: '1.2.7',  {export = false}
-					build   name: 'release',             version: '3.1.2',  {export = false}
-					build   name: 'rest-client-builder', version: '2.0.1',  {export = false}
+					test    name: 'code-coverage',       version: '2.0.3-3', {export = false}
+					build   name: 'release',             version: '3.1.2',   {export = false}
+					build   name: 'rest-client-builder', version: '2.1.1',   {export = false}
 					compile name: 'webxml',              version: '1.4.1'
 				}
 			}


### PR DESCRIPTION
Removed rhino since it is transitively included via asset-pipeline-core

Upgraded the following to current versions:
asset-pipeline-core
code-coverage
rest-client-builder