### PR TITLE
Manifest access cleanup

### DIFF
--- a/grails-app/conf/AssetPipelineBootStrap.groovy
+++ b/grails-app/conf/AssetPipelineBootStrap.groovy
@@ -21,8 +21,8 @@ class AssetPipelineBootStrap {
 		final Properties manifest = AssetPipelineConfigHolder.manifest
 
 		if (manifest) {
-			final boolean enableDigests  = true
-			final boolean skipNonDigests = true
+			final boolean enableDigests  = assetProcessorService.isEnableDigests(conf)
+			final boolean skipNonDigests = assetProcessorService.isSkipNonDigests(conf)
 
 			if (enableDigests || ! skipNonDigests) {
 				final File storageDir = new File((String) storagePath)

--- a/grails-app/services/asset/pipeline/grails/AssetProcessorService.groovy
+++ b/grails-app/services/asset/pipeline/grails/AssetProcessorService.groovy
@@ -33,7 +33,7 @@ class AssetProcessorService {
 	 * @throws IllegalArgumentException if the path contains <code>/</code>
 	 */
 	String getAssetMapping() {
-		final def mapping = grailsApplication.config?.grails?.assets?.mapping ?: 'assets'
+		final String mapping = grailsApplication.config?.grails?.assets?.mapping ?: 'assets'
 		if (mapping.contains('/')) {
 			throw new IllegalArgumentException(
 				'The property [grails.assets.mapping] can only be one level deep.  ' +
@@ -76,7 +76,7 @@ class AssetProcessorService {
 
 		url = assetBaseUrl(null, NONE) + url
 		if (! hasAuthority(url)) {
-			def absolutePath = linkGenerator.handleAbsolute(attrs)
+			String absolutePath = linkGenerator.handleAbsolute(attrs)
 
 			if (absolutePath == null) {
 				final String contextPath = attrs.contextPath?.toString() ?: linkGenerator.contextPath
@@ -117,7 +117,7 @@ class AssetProcessorService {
 				break
 		}
 
-		def finalUrl = ensureEndsWith(new StringBuilder(baseUrl.length() + mapping.length() + 2).append(baseUrl), '/' as char)
+		String finalUrl = ensureEndsWith(new StringBuilder(baseUrl.length() + mapping.length() + 2).append(baseUrl), '/' as char)
 			.append(mapping)
 			.append('/' as char)
 			.toString()

--- a/grails-app/services/asset/pipeline/grails/AssetProcessorService.groovy
+++ b/grails-app/services/asset/pipeline/grails/AssetProcessorService.groovy
@@ -54,9 +54,9 @@ class AssetProcessorService {
 	String getResolvedAssetPath(final String path, final ConfigObject conf = grailsApplication.config.grails.assets) {
 		final String relativePath = trimLeadingSlash(path)
 		if(manifest) {
-			manifest.getProperty(relativePath)
+			return manifest.getProperty(relativePath)
 		} else {
-			AssetHelper.fileForFullName(relativePath) != null ? relativePath : null
+			return AssetHelper.fileForFullName(relativePath) != null ? relativePath : null
 		}
 	}
 

--- a/grails-app/services/asset/pipeline/grails/AssetProcessorService.groovy
+++ b/grails-app/services/asset/pipeline/grails/AssetProcessorService.groovy
@@ -1,12 +1,12 @@
 package asset.pipeline.grails
 
 
+import asset.pipeline.AssetHelper
+import grails.util.Environment
 import javax.servlet.http.HttpServletRequest
 import org.codehaus.groovy.grails.web.mapping.DefaultLinkGenerator
 import org.codehaus.groovy.grails.web.servlet.mvc.GrailsWebRequest
-import grails.util.Environment
 
-import asset.pipeline.AssetHelper
 import static asset.pipeline.AssetPipelineConfigHolder.manifest
 import static asset.pipeline.grails.UrlBase.*
 import static asset.pipeline.grails.utils.net.HttpServletRequests.getBaseUrlWithScheme
@@ -58,7 +58,7 @@ class AssetProcessorService {
 		} else {
 			AssetHelper.fileForFullName(relativePath) != null ? relativePath : null
 		}
-		
+
 	}
 
 

--- a/grails-app/services/asset/pipeline/grails/AssetProcessorService.groovy
+++ b/grails-app/services/asset/pipeline/grails/AssetProcessorService.groovy
@@ -117,7 +117,7 @@ class AssetProcessorService {
 				break
 		}
 
-		String finalUrl = ensureEndsWith(new StringBuilder(baseUrl.length() + mapping.length() + 2).append(baseUrl), '/' as char)
+		final String finalUrl = ensureEndsWith(new StringBuilder(baseUrl.length() + mapping.length() + 2).append(baseUrl), '/' as char)
 			.append(mapping)
 			.append('/' as char)
 			.toString()

--- a/grails-app/services/asset/pipeline/grails/AssetProcessorService.groovy
+++ b/grails-app/services/asset/pipeline/grails/AssetProcessorService.groovy
@@ -47,14 +47,14 @@ class AssetProcessorService {
 
 	String getAssetPath(final String path, final ConfigObject conf = grailsApplication.config.grails.assets) {
 		final String relativePath = trimLeadingSlash(path)
-		return manifest?.getProperty(relativePath, relativePath) ?: relativePath
+		return manifest?.getProperty(relativePath) ?: relativePath
 	}
 
 
 	String getResolvedAssetPath(final String path, final ConfigObject conf = grailsApplication.config.grails.assets) {
 		final String relativePath = trimLeadingSlash(path)
 		if(manifest) {
-			manifest?.getProperty(relativePath)
+			manifest.getProperty(relativePath)
 		} else {
 			AssetHelper.fileForFullName(relativePath) != null ? relativePath : null
 		}

--- a/grails-app/services/asset/pipeline/grails/AssetProcessorService.groovy
+++ b/grails-app/services/asset/pipeline/grails/AssetProcessorService.groovy
@@ -47,7 +47,7 @@ class AssetProcessorService {
 
 	String getAssetPath(final String path, final ConfigObject conf = grailsApplication.config.grails.assets) {
 		final String relativePath = trimLeadingSlash(path)
-		return manifest?.getProperty(relativePath,relativePath) ?: relativePath
+		return manifest?.getProperty(relativePath, relativePath) ?: relativePath
 	}
 
 
@@ -58,7 +58,6 @@ class AssetProcessorService {
 		} else {
 			AssetHelper.fileForFullName(relativePath) != null ? relativePath : null
 		}
-
 	}
 
 
@@ -119,9 +118,9 @@ class AssetProcessorService {
 		}
 
 		def finalUrl = ensureEndsWith(new StringBuilder(baseUrl.length() + mapping.length() + 2).append(baseUrl), '/' as char)
-				.append(mapping)
-				.append('/' as char)
-				.toString()
+			.append(mapping)
+			.append('/' as char)
+			.toString()
 		return finalUrl
 	}
 

--- a/grails-app/services/asset/pipeline/grails/AssetProcessorService.groovy
+++ b/grails-app/services/asset/pipeline/grails/AssetProcessorService.groovy
@@ -44,17 +44,33 @@ class AssetProcessorService {
 	}
 
 
+	boolean isEnableDigests(final ConfigObject conf = grailsApplication.config.grails.assets) {
+		!conf.containsKey('enableDigests') || conf.enableDigests
+	}
+
+	boolean isSkipNonDigests(final ConfigObject conf = grailsApplication.config.grails.assets) {
+		!conf.containsKey('skipNonDigests') || conf.skipNonDigests
+	}
+
 
 	String getAssetPath(final String path, final ConfigObject conf = grailsApplication.config.grails.assets) {
 		final String relativePath = trimLeadingSlash(path)
-		return manifest?.getProperty(relativePath) ?: relativePath
+		if(isEnableDigests(conf)) {
+			return manifest?.getProperty(relativePath) ?: relativePath
+		} else {
+			return relativePath
+		}
 	}
 
 
 	String getResolvedAssetPath(final String path, final ConfigObject conf = grailsApplication.config.grails.assets) {
 		final String relativePath = trimLeadingSlash(path)
 		if(manifest) {
-			return manifest.getProperty(relativePath)
+			if(isEnableDigests(conf)) {
+				return manifest.getProperty(relativePath)
+			} else {
+				return manifest.getProperty(relativePath) ? relativePath : null
+			}
 		} else {
 			return AssetHelper.fileForFullName(relativePath) != null ? relativePath : null
 		}

--- a/src/groovy/asset/pipeline/grails/AssetPipelineFilter.groovy
+++ b/src/groovy/asset/pipeline/grails/AssetPipelineFilter.groovy
@@ -25,15 +25,18 @@ class AssetPipelineFilter implements Filter {
 	def warDeployed
 
 
+	@Override
 	void init(FilterConfig config) throws ServletException {
 		applicationContext = WebApplicationContextUtils.getWebApplicationContext(config.servletContext)
 		servletContext = config.servletContext
 		warDeployed = Environment.isWarDeployed()
 	}
 
+	@Override
 	void destroy() {
 	}
 
+	@Override
 	void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
 		def mapping = applicationContext.assetProcessorService.assetMapping
 

--- a/src/groovy/asset/pipeline/grails/AssetPipelineFilter.groovy
+++ b/src/groovy/asset/pipeline/grails/AssetPipelineFilter.groovy
@@ -16,7 +16,7 @@ import java.text.SimpleDateFormat
 class AssetPipelineFilter implements Filter {
 	public static final String HTTP_DATE_FORMAT = "EEE, dd MMM yyyy HH:mm:ss zzz"
 
-	public static final ProductionAssetCache fileCache = new ProductionAssetCache();
+	public static final ProductionAssetCache fileCache = new ProductionAssetCache()
 
 	def applicationContext
 	def servletContext
@@ -82,12 +82,12 @@ class AssetPipelineFilter implements Filter {
 						response.setContentType(format)
 						def inputStream
 						try {
-							byte[] buffer = new byte[102400];
-							int len;
+							byte[] buffer = new byte[102400]
+							int len
 							inputStream = file.inputStream
 							def out = response.outputStream
 							while ((len = inputStream.read(buffer)) != -1) {
-								out.write(buffer, 0, len);
+								out.write(buffer, 0, len)
 							}
 							response.flushBuffer()
 						} catch(e) {
@@ -147,12 +147,12 @@ class AssetPipelineFilter implements Filter {
 						response.setHeader('Content-Length', file.contentLength().toString())
 						def inputStream
 						try {
-							byte[] buffer = new byte[102400];
-							int len;
+							byte[] buffer = new byte[102400]
+							int len
 							inputStream = file.inputStream
 							def out = response.outputStream
 							while ((len = inputStream.read(buffer)) != -1) {
-								out.write(buffer, 0, len);
+								out.write(buffer, 0, len)
 							}
 							response.flushBuffer()
 						} catch(e) {
@@ -206,8 +206,8 @@ class AssetPipelineFilter implements Filter {
 	boolean hasNotChanged(String ifModifiedSince, Date date) {
 		boolean hasNotChanged = false
 		if (ifModifiedSince) {
-			final SimpleDateFormat sdf = new SimpleDateFormat(HTTP_DATE_FORMAT);
-			sdf.setTimeZone(TimeZone.getTimeZone("GMT"));
+			final SimpleDateFormat sdf = new SimpleDateFormat(HTTP_DATE_FORMAT)
+			sdf.setTimeZone(TimeZone.getTimeZone("GMT"))
 			try {
 				hasNotChanged = new Date(file?.lastModified()) <= sdf.parse(ifModifiedSince)
 			} catch (Exception e) {
@@ -217,8 +217,8 @@ class AssetPipelineFilter implements Filter {
 		return hasNotChanged
 	}
 	private String getLastModifiedDate(Date date) {
-		final SimpleDateFormat sdf = new SimpleDateFormat(HTTP_DATE_FORMAT);
-		sdf.setTimeZone(TimeZone.getTimeZone("GMT"));
+		final SimpleDateFormat sdf = new SimpleDateFormat(HTTP_DATE_FORMAT)
+		sdf.setTimeZone(TimeZone.getTimeZone("GMT"))
 		String lastModifiedDateTimeString = sdf.format(new Date())
 		try {
 			lastModifiedDateTimeString = sdf.format(date)

--- a/src/groovy/asset/pipeline/grails/AssetPipelineFilter.groovy
+++ b/src/groovy/asset/pipeline/grails/AssetPipelineFilter.groovy
@@ -98,7 +98,7 @@ class AssetPipelineFilter implements Filter {
 							response.flushBuffer()
 						} catch(e) {
 							log.debug("File Transfer Aborted (Probably by the user)", e)
-						}finally {
+						} finally {
 							try { inputStream?.close()} catch(ie){/*silent close fail*/}
 						}
 					} else {

--- a/src/groovy/asset/pipeline/grails/AssetPipelineFilter.groovy
+++ b/src/groovy/asset/pipeline/grails/AssetPipelineFilter.groovy
@@ -15,9 +15,9 @@ import java.text.SimpleDateFormat
 @Slf4j
 class AssetPipelineFilter implements Filter {
 
-	public static final String HTTP_DATE_FORMAT = "EEE, dd MMM yyyy HH:mm:ss zzz"
+	static final String HTTP_DATE_FORMAT = "EEE, dd MMM yyyy HH:mm:ss zzz"
 
-	public static final ProductionAssetCache fileCache = new ProductionAssetCache()
+	static final ProductionAssetCache fileCache = new ProductionAssetCache()
 
 
 	def applicationContext

--- a/src/groovy/asset/pipeline/grails/AssetPipelineFilter.groovy
+++ b/src/groovy/asset/pipeline/grails/AssetPipelineFilter.groovy
@@ -1,5 +1,6 @@
 package asset.pipeline.grails
 
+
 import asset.pipeline.AssetPipeline
 import asset.pipeline.AssetPipelineConfigHolder
 import asset.pipeline.AssetPipelineResponseBuilder
@@ -8,13 +9,13 @@ import groovy.util.logging.Slf4j
 import org.springframework.web.context.support.WebApplicationContextUtils
 
 import javax.servlet.*
-import java.util.TimeZone
 import java.text.SimpleDateFormat
+
 
 @Slf4j
 class AssetPipelineFilter implements Filter {
 	public static final String HTTP_DATE_FORMAT = "EEE, dd MMM yyyy HH:mm:ss zzz"
-	
+
 	public static final ProductionAssetCache fileCache = new ProductionAssetCache();
 
 	def applicationContext
@@ -64,7 +65,7 @@ class AssetPipelineFilter implements Filter {
 					if(responseBuilder.statusCode) {
 						response.status = responseBuilder.statusCode
 					}
-					
+
 					if(responseBuilder.statusCode != 304) {
 						def acceptsEncoding = request.getHeader("Accept-Encoding")
 						if(acceptsEncoding?.split(",")?.contains("gzip") && attributeCache.gzipExists()) {
@@ -101,7 +102,7 @@ class AssetPipelineFilter implements Filter {
 					response.status = 404
 					response.flushBuffer()
 				}
-				
+
 			} else {
 				def file = applicationContext.getResource("assets/${fileUri}")
 				if(!file.exists()) {
@@ -120,7 +121,7 @@ class AssetPipelineFilter implements Filter {
 					if(responseBuilder.statusCode) {
 						response.status = responseBuilder.statusCode
 					}
-					
+
 
 					def gzipFile = applicationContext.getResource("assets/${fileUri}.gz")
 					if(!gzipFile.exists()) {

--- a/src/groovy/asset/pipeline/grails/AssetPipelineFilter.groovy
+++ b/src/groovy/asset/pipeline/grails/AssetPipelineFilter.groovy
@@ -14,15 +14,18 @@ import java.text.SimpleDateFormat
 
 @Slf4j
 class AssetPipelineFilter implements Filter {
+
 	public static final String HTTP_DATE_FORMAT = "EEE, dd MMM yyyy HH:mm:ss zzz"
 
 	public static final ProductionAssetCache fileCache = new ProductionAssetCache()
 
+
 	def applicationContext
 	def servletContext
 	def warDeployed
-	void init(FilterConfig config) throws ServletException {
 
+
+	void init(FilterConfig config) throws ServletException {
 		applicationContext = WebApplicationContextUtils.getWebApplicationContext(config.servletContext)
 		servletContext = config.servletContext
 		warDeployed = Environment.isWarDeployed()
@@ -54,10 +57,10 @@ class AssetPipelineFilter implements Filter {
 			if(attributeCache) {
 				if(attributeCache.exists()) {
 					def file = attributeCache.resource
-					def responseBuilder = new AssetPipelineResponseBuilder(fileUri,request.getHeader('If-None-Match'), request.getHeader('If-Modified-Since'))
+					def responseBuilder = new AssetPipelineResponseBuilder(fileUri, request.getHeader('If-None-Match'), request.getHeader('If-Modified-Since'))
 					response.setHeader('Last-Modified', getLastModifiedDate(attributeCache.getLastModified()))
 					responseBuilder.headers.each { header ->
-						response.setHeader(header.key,header.value)
+						response.setHeader(header.key, header.value)
 					}
 					if (hasNotChanged(responseBuilder.ifModifiedSinceHeader, attributeCache.getLastModified())) {
 						responseBuilder.statusCode = 304
@@ -70,7 +73,7 @@ class AssetPipelineFilter implements Filter {
 						def acceptsEncoding = request.getHeader("Accept-Encoding")
 						if(acceptsEncoding?.split(",")?.contains("gzip") && attributeCache.gzipExists()) {
 							file = attributeCache.getGzipResource()
-							response.setHeader('Content-Encoding','gzip')
+							response.setHeader('Content-Encoding', 'gzip')
 							response.setHeader('Content-Length', attributeCache.getGzipFileSize().toString())
 						} else {
 							response.setHeader('Content-Length', attributeCache.getFileSize().toString())
@@ -91,7 +94,7 @@ class AssetPipelineFilter implements Filter {
 							}
 							response.flushBuffer()
 						} catch(e) {
-							log.debug("File Transfer Aborted (Probably by the user)",e)
+							log.debug("File Transfer Aborted (Probably by the user)", e)
 						}finally {
 							try { inputStream?.close()} catch(ie){/*silent close fail*/}
 						}
@@ -102,7 +105,6 @@ class AssetPipelineFilter implements Filter {
 					response.status = 404
 					response.flushBuffer()
 				}
-
 			} else {
 				def file = applicationContext.getResource("assets/${fileUri}")
 				if(!file.exists()) {
@@ -110,18 +112,17 @@ class AssetPipelineFilter implements Filter {
 				}
 
 				if(file.exists()) {
-					def responseBuilder = new AssetPipelineResponseBuilder(fileUri,request.getHeader('If-None-Match'), request.getHeader('If-Modified-Since'))
+					def responseBuilder = new AssetPipelineResponseBuilder(fileUri, request.getHeader('If-None-Match'), request.getHeader('If-Modified-Since'))
 					response.setHeader('Last-Modified', getLastModifiedDate(new Date(file.lastModified())))
 					if (hasNotChanged(responseBuilder.ifModifiedSinceHeader, new Date(file.lastModified()))) {
 						responseBuilder.statusCode = 304
 					}
 					responseBuilder.headers.each { header ->
-						response.setHeader(header.key,header.value)
+						response.setHeader(header.key, header.value)
 					}
 					if(responseBuilder.statusCode) {
 						response.status = responseBuilder.statusCode
 					}
-
 
 					def gzipFile = applicationContext.getResource("assets/${fileUri}.gz")
 					if(!gzipFile.exists()) {
@@ -137,7 +138,7 @@ class AssetPipelineFilter implements Filter {
 						if(acceptsEncoding?.split(",")?.contains("gzip")) {
 							if(gzipFile.exists()) {
 								file = gzipFile
-								response.setHeader('Content-Encoding','gzip')
+								response.setHeader('Content-Encoding', 'gzip')
 							}
 						}
 						if(encoding) {
@@ -156,7 +157,7 @@ class AssetPipelineFilter implements Filter {
 							}
 							response.flushBuffer()
 						} catch(e) {
-							log.debug("File Transfer Aborted (Probably by the user)",e)
+							log.debug("File Transfer Aborted (Probably by the user)", e)
 						} finally {
 							try { inputStream?.close()} catch(ie){/*silent close fail*/}
 						}
@@ -173,13 +174,12 @@ class AssetPipelineFilter implements Filter {
 		} else {
 			def fileContents
 			if(request.getParameter('compile') == 'false') {
-				fileContents = AssetPipeline.serveUncompiledAsset(fileUri,format, null, encoding)
+				fileContents = AssetPipeline.serveUncompiledAsset(fileUri, format, null, encoding)
 			} else {
-				fileContents = AssetPipeline.serveAsset(fileUri,format, null, encoding)
+				fileContents = AssetPipeline.serveAsset(fileUri, format, null, encoding)
 			}
 
 			if (fileContents != null) {
-
 				response.setHeader("Cache-Control", "no-cache, no-store, must-revalidate") // HTTP 1.1.
 				response.setHeader("Pragma", "no-cache") // HTTP 1.0.
 				response.setDateHeader("Expires", 0) // Proxies.
@@ -190,7 +190,7 @@ class AssetPipelineFilter implements Filter {
 					response.outputStream << fileContents
 					response.flushBuffer()
 				} catch(e) {
-					log.debug("File Transfer Aborted (Probably by the user)",e)
+					log.debug("File Transfer Aborted (Probably by the user)", e)
 				}
 			} else {
 				response.status = 404
@@ -198,11 +198,11 @@ class AssetPipelineFilter implements Filter {
 			}
 		}
 
-
 		if (!response.committed) {
 			chain.doFilter(request, response)
 		}
 	}
+
 	boolean hasNotChanged(String ifModifiedSince, Date date) {
 		boolean hasNotChanged = false
 		if (ifModifiedSince) {
@@ -216,6 +216,7 @@ class AssetPipelineFilter implements Filter {
 		}
 		return hasNotChanged
 	}
+
 	private String getLastModifiedDate(Date date) {
 		final SimpleDateFormat sdf = new SimpleDateFormat(HTTP_DATE_FORMAT)
 		sdf.setTimeZone(TimeZone.getTimeZone("GMT"))
@@ -228,5 +229,4 @@ class AssetPipelineFilter implements Filter {
 
 		return lastModifiedDateTimeString
 	}
-
 }

--- a/src/groovy/asset/pipeline/grails/AssetPipelineFilter.groovy
+++ b/src/groovy/asset/pipeline/grails/AssetPipelineFilter.groovy
@@ -2,7 +2,6 @@ package asset.pipeline.grails
 
 
 import asset.pipeline.AssetPipeline
-import asset.pipeline.AssetPipelineConfigHolder
 import asset.pipeline.AssetPipelineResponseBuilder
 import grails.util.Environment
 import groovy.util.logging.Slf4j
@@ -51,12 +50,7 @@ class AssetPipelineFilter implements Filter {
 			fileUri = fileUri.substring(baseAssetUrl.length())
 		}
 		if(warDeployed) {
-			final Properties manifest = AssetPipelineConfigHolder.manifest
-			String manifestPath = fileUri
-			if(fileUri.startsWith('/')) {
-			  manifestPath = fileUri.substring(1) //Omit forward slash
-			}
-			fileUri = manifest?.getProperty(manifestPath, manifestPath)
+			fileUri = applicationContext.assetProcessorService.getAssetPath(fileUri)
 
 			final AssetAttributes attributeCache = fileCache.get(fileUri)
 

--- a/src/groovy/asset/pipeline/grails/AssetResourceLocator.groovy
+++ b/src/groovy/asset/pipeline/grails/AssetResourceLocator.groovy
@@ -1,13 +1,15 @@
 package asset.pipeline.grails
 
+
 import asset.pipeline.AssetHelper
 import asset.pipeline.AssetPipelineConfigHolder
 import asset.pipeline.DirectiveProcessor
 import asset.pipeline.GenericAssetFile
+import groovy.util.logging.Slf4j
 import org.codehaus.groovy.grails.core.io.DefaultResourceLocator
 import org.springframework.core.io.ByteArrayResource
 import org.springframework.core.io.Resource
-import groovy.util.logging.Slf4j
+
 
 @Slf4j
 class AssetResourceLocator extends DefaultResourceLocator {

--- a/src/groovy/asset/pipeline/grails/AssetResourceLocator.groovy
+++ b/src/groovy/asset/pipeline/grails/AssetResourceLocator.groovy
@@ -40,14 +40,10 @@ class AssetResourceLocator extends DefaultResourceLocator {
 			}
 		} else {
 			List<String> contentTypes = AssetHelper.assetMimeTypeForURI(uri)
-			String contentType
-			if(contentTypes) {
-				contentType = contentTypes[0]
-			}
-
-			String    extension = AssetHelper.extensionFromURI(uri)
-			String    name      = AssetHelper.nameWithoutExtension(uri)
-			AssetFile assetFile = AssetHelper.fileForUri(name, contentType, extension)
+			String       contentType  = contentTypes ? contentTypes[0] : null
+			String       extension    = AssetHelper.extensionFromURI(uri)
+			String       name         = AssetHelper.nameWithoutExtension(uri)
+			AssetFile    assetFile    = AssetHelper.fileForUri(name, contentType, extension)
 			if(assetFile) {
 				if(assetFile instanceof GenericAssetFile) {
 					resource = new ByteArrayResource(assetFile.bytes)

--- a/src/groovy/asset/pipeline/grails/AssetResourceLocator.groovy
+++ b/src/groovy/asset/pipeline/grails/AssetResourceLocator.groovy
@@ -3,9 +3,9 @@ package asset.pipeline.grails
 
 import asset.pipeline.AssetFile
 import asset.pipeline.AssetHelper
-import asset.pipeline.AssetPipelineConfigHolder
 import asset.pipeline.DirectiveProcessor
 import asset.pipeline.GenericAssetFile
+import grails.util.Holders
 import groovy.util.logging.Slf4j
 import org.codehaus.groovy.grails.core.io.DefaultResourceLocator
 import org.springframework.core.io.ByteArrayResource
@@ -27,8 +27,7 @@ class AssetResourceLocator extends DefaultResourceLocator {
 	Resource findAssetForURI(String uri) {
 		final Resource resource
 		if(warDeployed) {
-			final Properties manifest = AssetPipelineConfigHolder.manifest
-			uri = manifest?.getProperty(uri, uri)
+			uri = Holders.grailsApplication.mainContext.getBean(AssetProcessorService).getAssetPath(uri)
 
 			final String assetUri = "assets/${uri}"
 			Resource defaultResource = defaultResourceLoader.getResource(assetUri)

--- a/src/groovy/asset/pipeline/grails/AssetResourceLocator.groovy
+++ b/src/groovy/asset/pipeline/grails/AssetResourceLocator.groovy
@@ -13,6 +13,7 @@ import org.springframework.core.io.Resource
 
 @Slf4j
 class AssetResourceLocator extends DefaultResourceLocator {
+
 	Resource findResourceForURI(String uri) {
 		Resource resource = super.findResourceForURI(uri)
 		if(!resource) {
@@ -42,9 +43,9 @@ class AssetResourceLocator extends DefaultResourceLocator {
 				contentType = contentTypes[0]
 			}
 
-			def extension    = AssetHelper.extensionFromURI(uri)
-			def name         = AssetHelper.nameWithoutExtension(uri)
-			def assetFile    = AssetHelper.fileForUri(name,contentType,extension)
+			def extension = AssetHelper.extensionFromURI(uri)
+			def name      = AssetHelper.nameWithoutExtension(uri)
+			def assetFile = AssetHelper.fileForUri(name, contentType, extension)
 			if(assetFile) {
 				if(assetFile instanceof GenericAssetFile) {
 					resource = new ByteArrayResource(assetFile.bytes)

--- a/src/groovy/asset/pipeline/grails/AssetResourceLocator.groovy
+++ b/src/groovy/asset/pipeline/grails/AssetResourceLocator.groovy
@@ -14,6 +14,7 @@ import org.springframework.core.io.Resource
 @Slf4j
 class AssetResourceLocator extends DefaultResourceLocator {
 
+	@Override
 	Resource findResourceForURI(String uri) {
 		Resource resource = super.findResourceForURI(uri)
 		if(!resource) {

--- a/src/groovy/asset/pipeline/grails/AssetResourceLocator.groovy
+++ b/src/groovy/asset/pipeline/grails/AssetResourceLocator.groovy
@@ -16,7 +16,7 @@ import org.springframework.core.io.Resource
 class AssetResourceLocator extends DefaultResourceLocator {
 
 	@Override
-	Resource findResourceForURI(String uri) {
+	Resource findResourceForURI(final String uri) {
 		Resource resource = super.findResourceForURI(uri)
 		if(!resource) {
 			resource = findAssetForURI(uri)
@@ -25,12 +25,12 @@ class AssetResourceLocator extends DefaultResourceLocator {
 	}
 
 	Resource findAssetForURI(String uri) {
-		Resource resource
+		final Resource resource
 		if(warDeployed) {
-			Properties manifest = AssetPipelineConfigHolder.manifest
+			final Properties manifest = AssetPipelineConfigHolder.manifest
 			uri = manifest?.getProperty(uri, uri)
 
-			String assetUri = "assets/${uri}"
+			final String assetUri = "assets/${uri}"
 			Resource defaultResource = defaultResourceLoader.getResource(assetUri)
 			if (!defaultResource?.exists()) {
 				defaultResource = defaultResourceLoader.getResource("classpath:${assetUri}")
@@ -39,18 +39,18 @@ class AssetResourceLocator extends DefaultResourceLocator {
 				resource = defaultResource
 			}
 		} else {
-			List<String> contentTypes = AssetHelper.assetMimeTypeForURI(uri)
-			String       contentType  = contentTypes ? contentTypes[0] : null
-			String       extension    = AssetHelper.extensionFromURI(uri)
-			String       name         = AssetHelper.nameWithoutExtension(uri)
-			AssetFile    assetFile    = AssetHelper.fileForUri(name, contentType, extension)
+			final List<String> contentTypes = AssetHelper.assetMimeTypeForURI(uri)
+			final String       contentType  = contentTypes ? contentTypes[0] : null
+			final String       extension    = AssetHelper.extensionFromURI(uri)
+			final String       name         = AssetHelper.nameWithoutExtension(uri)
+			final AssetFile    assetFile    = AssetHelper.fileForUri(name, contentType, extension)
 			if(assetFile) {
 				if(assetFile instanceof GenericAssetFile) {
 					resource = new ByteArrayResource(assetFile.bytes)
 				} else {
-					DirectiveProcessor directiveProcessor = new DirectiveProcessor(contentType, null, this.class.classLoader)
-					def fileContents = directiveProcessor.compile(assetFile)
-					String encoding = assetFile.encoding
+					final DirectiveProcessor directiveProcessor = new DirectiveProcessor(contentType, null, this.class.classLoader)
+					final def fileContents = directiveProcessor.compile(assetFile)
+					final String encoding = assetFile.encoding
 					if(encoding) {
 						resource = new ByteArrayResource(fileContents.getBytes(encoding))
 					} else {

--- a/src/groovy/asset/pipeline/grails/AssetResourceLocator.groovy
+++ b/src/groovy/asset/pipeline/grails/AssetResourceLocator.groovy
@@ -1,6 +1,7 @@
 package asset.pipeline.grails
 
 
+import asset.pipeline.AssetFile
 import asset.pipeline.AssetHelper
 import asset.pipeline.AssetPipelineConfigHolder
 import asset.pipeline.DirectiveProcessor
@@ -26,10 +27,10 @@ class AssetResourceLocator extends DefaultResourceLocator {
 	Resource findAssetForURI(String uri) {
 		Resource resource
 		if(warDeployed) {
-			def manifest = AssetPipelineConfigHolder.manifest
+			Properties manifest = AssetPipelineConfigHolder.manifest
 			uri = manifest?.getProperty(uri, uri)
 
-			def assetUri = "assets/${uri}"
+			String assetUri = "assets/${uri}"
 			Resource defaultResource = defaultResourceLoader.getResource(assetUri)
 			if (!defaultResource?.exists()) {
 				defaultResource = defaultResourceLoader.getResource("classpath:${assetUri}")
@@ -38,22 +39,22 @@ class AssetResourceLocator extends DefaultResourceLocator {
 				resource = defaultResource
 			}
 		} else {
-			def contentTypes = AssetHelper.assetMimeTypeForURI(uri)
-			def contentType
+			List<String> contentTypes = AssetHelper.assetMimeTypeForURI(uri)
+			String contentType
 			if(contentTypes) {
 				contentType = contentTypes[0]
 			}
 
-			def extension = AssetHelper.extensionFromURI(uri)
-			def name      = AssetHelper.nameWithoutExtension(uri)
-			def assetFile = AssetHelper.fileForUri(name, contentType, extension)
+			String    extension = AssetHelper.extensionFromURI(uri)
+			String    name      = AssetHelper.nameWithoutExtension(uri)
+			AssetFile assetFile = AssetHelper.fileForUri(name, contentType, extension)
 			if(assetFile) {
 				if(assetFile instanceof GenericAssetFile) {
 					resource = new ByteArrayResource(assetFile.bytes)
 				} else {
-					def directiveProcessor = new DirectiveProcessor(contentType, null, this.class.classLoader)
+					DirectiveProcessor directiveProcessor = new DirectiveProcessor(contentType, null, this.class.classLoader)
 					def fileContents = directiveProcessor.compile(assetFile)
-					def encoding = assetFile.encoding
+					String encoding = assetFile.encoding
 					if(encoding) {
 						resource = new ByteArrayResource(fileContents.getBytes(encoding))
 					} else {


### PR DESCRIPTION
Please see commits for changes.

I cleaned up 4 files.

I performed only one type of cleanup per commit to make it easy to see each step of the cleanup.

The earlier commits are very simple cleanups, like adding @Override, or organizing imports, etc.

The later commits are more useful, reusing code instead of using copied code in multiple places, fixing up some minor bugs & minor performance inefficiencies along the way, and enabling a few optional configs (that have the same default behavior as current AP if the config option isn't specified).