### PR TITLE
Service to core

### DIFF
--- a/grails-app/services/asset/pipeline/grails/AssetProcessorService.groovy
+++ b/grails-app/services/asset/pipeline/grails/AssetProcessorService.groovy
@@ -33,7 +33,7 @@ class AssetProcessorService {
 	 * @throws IllegalArgumentException if the path contains <code>/</code>
 	 */
 	String getAssetMapping() {
-		final def mapping = grailsApplication.config?.grails?.assets?.mapping ?: 'assets'
+		final String mapping = grailsApplication.config?.grails?.assets?.mapping ?: 'assets'
 		if (mapping.contains('/')) {
 			throw new IllegalArgumentException(
 				'The property [grails.assets.mapping] can only be one level deep.  ' +
@@ -76,7 +76,7 @@ class AssetProcessorService {
 
 		url = assetBaseUrl(null, NONE) + url
 		if (! hasAuthority(url)) {
-			def absolutePath = linkGenerator.handleAbsolute(attrs)
+			String absolutePath = linkGenerator.handleAbsolute(attrs)
 
 			if (absolutePath == null) {
 				final String contextPath = attrs.contextPath?.toString() ?: linkGenerator.contextPath
@@ -117,7 +117,7 @@ class AssetProcessorService {
 				break
 		}
 
-		def finalUrl = ensureEndsWith(new StringBuilder(baseUrl.length() + mapping.length() + 2).append(baseUrl), '/' as char)
+		String finalUrl = ensureEndsWith(new StringBuilder(baseUrl.length() + mapping.length() + 2).append(baseUrl), '/' as char)
 			.append(mapping)
 			.append('/' as char)
 			.toString()

--- a/grails-app/services/asset/pipeline/grails/AssetProcessorService.groovy
+++ b/grails-app/services/asset/pipeline/grails/AssetProcessorService.groovy
@@ -54,9 +54,9 @@ class AssetProcessorService {
 	String getResolvedAssetPath(final String path, final ConfigObject conf = grailsApplication.config.grails.assets) {
 		final String relativePath = trimLeadingSlash(path)
 		if(manifest) {
-			manifest.getProperty(relativePath)
+			return manifest.getProperty(relativePath)
 		} else {
-			AssetHelper.fileForFullName(relativePath) != null ? relativePath : null
+			return AssetHelper.fileForFullName(relativePath) != null ? relativePath : null
 		}
 	}
 

--- a/grails-app/services/asset/pipeline/grails/AssetProcessorService.groovy
+++ b/grails-app/services/asset/pipeline/grails/AssetProcessorService.groovy
@@ -1,12 +1,12 @@
 package asset.pipeline.grails
 
 
+import asset.pipeline.AssetHelper
+import grails.util.Environment
 import javax.servlet.http.HttpServletRequest
 import org.codehaus.groovy.grails.web.mapping.DefaultLinkGenerator
 import org.codehaus.groovy.grails.web.servlet.mvc.GrailsWebRequest
-import grails.util.Environment
 
-import asset.pipeline.AssetHelper
 import static asset.pipeline.AssetPipelineConfigHolder.manifest
 import static asset.pipeline.grails.UrlBase.*
 import static asset.pipeline.grails.utils.net.HttpServletRequests.getBaseUrlWithScheme
@@ -58,7 +58,7 @@ class AssetProcessorService {
 		} else {
 			AssetHelper.fileForFullName(relativePath) != null ? relativePath : null
 		}
-		
+
 	}
 
 

--- a/grails-app/services/asset/pipeline/grails/AssetProcessorService.groovy
+++ b/grails-app/services/asset/pipeline/grails/AssetProcessorService.groovy
@@ -20,6 +20,7 @@ class AssetProcessorService {
 	static transactional = false
 
 
+	// <editor-fold desc="Grails-specific methods">
 	/**
 	 * Retrieves the asset path from the property [grails.assets.mapping] which is used by the url mapping and the
 	 * taglib.  The property cannot contain <code>/</code>, and must be one level deep
@@ -36,28 +37,6 @@ class AssetProcessorService {
 			)
 		}
 		return mapping
-	}
-
-
-	String getAssetPath(final String path) {
-		final String relativePath = trimLeadingSlash(path)
-		return manifest?.getProperty(relativePath) ?: relativePath
-	}
-
-
-	String getResolvedAssetPath(final String path) {
-		final String relativePath = trimLeadingSlash(path)
-		if(manifest) {
-			return manifest.getProperty(relativePath)
-		} else {
-			return AssetHelper.fileForFullName(relativePath) != null ? relativePath : null
-		}
-	}
-
-
-	boolean isAssetPath(final String path) {
-		final String relativePath = trimLeadingSlash(path)
-		return relativePath && (manifest ? manifest.getProperty(relativePath) : AssetHelper.fileForFullName(relativePath) != null)
 	}
 
 
@@ -82,6 +61,44 @@ class AssetProcessorService {
 		return url
 	}
 
+
+	String makeServerURL(final DefaultLinkGenerator linkGenerator) {
+		String serverUrl = linkGenerator.configuredServerBaseURL
+		if (! serverUrl) {
+			final GrailsWebRequest req = lookup()
+			if (req) {
+				serverUrl = getBaseUrlWithScheme(req.currentRequest).toString()
+				if (!serverUrl && !Environment.isWarDeployed()) {
+					serverUrl = "http://localhost:${System.getProperty('server.port') ?: '8080'}${linkGenerator.contextPath ?: ''}"
+				}
+			}
+		}
+		return serverUrl
+	}
+	// </editor-fold>
+
+
+	String getAssetPath(final String path) {
+		final String relativePath = trimLeadingSlash(path)
+		return manifest?.getProperty(relativePath) ?: relativePath
+	}
+
+
+	String getResolvedAssetPath(final String path) {
+		final String relativePath = trimLeadingSlash(path)
+		if(manifest) {
+			return manifest.getProperty(relativePath)
+		} else {
+			return AssetHelper.fileForFullName(relativePath) != null ? relativePath : null
+		}
+	}
+
+
+	boolean isAssetPath(final String path) {
+		final String relativePath = trimLeadingSlash(path)
+		return relativePath && (manifest ? manifest.getProperty(relativePath) : AssetHelper.fileForFullName(relativePath) != null)
+	}
+
 	String getConfigBaseUrl(final HttpServletRequest req) {
 		final def url = config.url
 		if(url instanceof Closure) {
@@ -104,21 +121,6 @@ class AssetProcessorService {
 			.toString()
 
 		return finalUrl
-	}
-
-
-	String makeServerURL(final DefaultLinkGenerator linkGenerator) {
-		String serverUrl = linkGenerator.configuredServerBaseURL
-		if (! serverUrl) {
-			final GrailsWebRequest req = lookup()
-			if (req) {
-				serverUrl = getBaseUrlWithScheme(req.currentRequest).toString()
-				if (!serverUrl && !Environment.isWarDeployed()) {
-					serverUrl = "http://localhost:${System.getProperty('server.port') ?: '8080'}${linkGenerator.contextPath ?: ''}"
-				}
-			}
-		}
-		return serverUrl
 	}
 
 

--- a/grails-app/services/asset/pipeline/grails/AssetProcessorService.groovy
+++ b/grails-app/services/asset/pipeline/grails/AssetProcessorService.groovy
@@ -7,6 +7,7 @@ import javax.servlet.http.HttpServletRequest
 import org.codehaus.groovy.grails.web.mapping.DefaultLinkGenerator
 import org.codehaus.groovy.grails.web.servlet.mvc.GrailsWebRequest
 
+import static asset.pipeline.AssetPipelineConfigHolder.config
 import static asset.pipeline.AssetPipelineConfigHolder.manifest
 import static asset.pipeline.grails.UrlBase.*
 import static asset.pipeline.grails.utils.net.HttpServletRequests.getBaseUrlWithScheme
@@ -21,7 +22,6 @@ class AssetProcessorService {
 	static transactional = false
 
 
-	def grailsApplication
 	def grailsLinkGenerator
 
 
@@ -33,7 +33,7 @@ class AssetProcessorService {
 	 * @throws IllegalArgumentException if the path contains <code>/</code>
 	 */
 	String getAssetMapping() {
-		final String mapping = grailsApplication.config?.grails?.assets?.mapping ?: 'assets'
+		final String mapping = config.mapping ?: 'assets'
 		if (mapping.contains('/')) {
 			throw new IllegalArgumentException(
 				'The property [grails.assets.mapping] can only be one level deep.  ' +
@@ -45,13 +45,13 @@ class AssetProcessorService {
 
 
 
-	String getAssetPath(final String path, final ConfigObject conf = grailsApplication.config.grails.assets) {
+	String getAssetPath(final String path) {
 		final String relativePath = trimLeadingSlash(path)
 		return manifest?.getProperty(relativePath) ?: relativePath
 	}
 
 
-	String getResolvedAssetPath(final String path, final ConfigObject conf = grailsApplication.config.grails.assets) {
+	String getResolvedAssetPath(final String path) {
 		final String relativePath = trimLeadingSlash(path)
 		if(manifest) {
 			return manifest.getProperty(relativePath)
@@ -88,16 +88,16 @@ class AssetProcessorService {
 		return url
 	}
 
-	String getConfigBaseUrl(final HttpServletRequest req, final ConfigObject conf = grailsApplication.config.grails.assets) {
-		final def url = conf.url
+	String getConfigBaseUrl(final HttpServletRequest req) {
+		final def url = config.url
 		if(url instanceof Closure) {
 			return url(req)
 		}
 		return url ?: null
 	}
 
-	String assetBaseUrl(final HttpServletRequest req, final UrlBase urlBase, final ConfigObject conf = grailsApplication.config.grails.assets) {
-		final String url = getConfigBaseUrl(req, conf)
+	String assetBaseUrl(final HttpServletRequest req, final UrlBase urlBase) {
+		final String url = getConfigBaseUrl(req)
 		if (url) {
 			return url
 		}

--- a/grails-app/services/asset/pipeline/grails/AssetProcessorService.groovy
+++ b/grails-app/services/asset/pipeline/grails/AssetProcessorService.groovy
@@ -39,7 +39,6 @@ class AssetProcessorService {
 	}
 
 
-
 	String getAssetPath(final String path) {
 		final String relativePath = trimLeadingSlash(path)
 		return manifest?.getProperty(relativePath) ?: relativePath

--- a/grails-app/services/asset/pipeline/grails/AssetProcessorService.groovy
+++ b/grails-app/services/asset/pipeline/grails/AssetProcessorService.groovy
@@ -99,6 +99,7 @@ class AssetProcessorService {
 		return relativePath && (manifest ? manifest.getProperty(relativePath) : AssetHelper.fileForFullName(relativePath) != null)
 	}
 
+
 	String getConfigBaseUrl(final HttpServletRequest req) {
 		final def url = config.url
 		if(url instanceof Closure) {
@@ -106,6 +107,7 @@ class AssetProcessorService {
 		}
 		return url ?: null
 	}
+
 
 	String assetBaseUrl(final HttpServletRequest req, final String baseUrl) {
 		final String url = getConfigBaseUrl(req)

--- a/grails-app/services/asset/pipeline/grails/AssetProcessorService.groovy
+++ b/grails-app/services/asset/pipeline/grails/AssetProcessorService.groovy
@@ -9,20 +9,15 @@ import org.codehaus.groovy.grails.web.servlet.mvc.GrailsWebRequest
 
 import static asset.pipeline.AssetPipelineConfigHolder.config
 import static asset.pipeline.AssetPipelineConfigHolder.manifest
-import static asset.pipeline.grails.UrlBase.*
 import static asset.pipeline.grails.utils.net.HttpServletRequests.getBaseUrlWithScheme
 import static asset.pipeline.grails.utils.text.StringBuilders.ensureEndsWith
 import static asset.pipeline.utils.net.Urls.hasAuthority
-import static org.apache.commons.lang.StringUtils.trimToEmpty
 import static org.codehaus.groovy.grails.web.servlet.mvc.GrailsWebRequest.lookup
 
 
 class AssetProcessorService {
 
 	static transactional = false
-
-
-	def grailsLinkGenerator
 
 
 	/**
@@ -74,7 +69,7 @@ class AssetProcessorService {
 			return null
 		}
 
-		url = assetBaseUrl(null, NONE) + url
+		url = assetBaseUrl(null, '') + url
 		if (! hasAuthority(url)) {
 			String absolutePath = linkGenerator.handleAbsolute(attrs)
 
@@ -96,7 +91,7 @@ class AssetProcessorService {
 		return url ?: null
 	}
 
-	String assetBaseUrl(final HttpServletRequest req, final UrlBase urlBase) {
+	String assetBaseUrl(final HttpServletRequest req, final String baseUrl) {
 		final String url = getConfigBaseUrl(req)
 		if (url) {
 			return url
@@ -104,23 +99,11 @@ class AssetProcessorService {
 
 		final String mapping = assetMapping
 
-		final String baseUrl
-		switch (urlBase) {
-			case SERVER_BASE_URL:
-				baseUrl = grailsLinkGenerator.serverBaseURL ?: ''
-				break
-			case CONTEXT_PATH:
-				baseUrl = trimToEmpty(grailsLinkGenerator.contextPath)
-				break
-			case NONE:
-				baseUrl = ''
-				break
-		}
-
 		final String finalUrl = ensureEndsWith(new StringBuilder(baseUrl.length() + mapping.length() + 2).append(baseUrl), '/' as char)
 			.append(mapping)
 			.append('/' as char)
 			.toString()
+
 		return finalUrl
 	}
 

--- a/grails-app/services/asset/pipeline/grails/AssetProcessorService.groovy
+++ b/grails-app/services/asset/pipeline/grails/AssetProcessorService.groovy
@@ -7,7 +7,7 @@ import javax.servlet.http.HttpServletRequest
 import org.codehaus.groovy.grails.web.mapping.DefaultLinkGenerator
 import org.codehaus.groovy.grails.web.servlet.mvc.GrailsWebRequest
 
-import static asset.pipeline.AssetPipelineConfigHolder.config
+import static asset.pipeline.AssetPipelineConfigHolder.getConfig
 import static asset.pipeline.AssetPipelineConfigHolder.manifest
 import static asset.pipeline.grails.utils.net.HttpServletRequests.getBaseUrlWithScheme
 import static asset.pipeline.grails.utils.text.StringBuilders.ensureEndsWith

--- a/grails-app/services/asset/pipeline/grails/AssetProcessorService.groovy
+++ b/grails-app/services/asset/pipeline/grails/AssetProcessorService.groovy
@@ -117,7 +117,7 @@ class AssetProcessorService {
 				break
 		}
 
-		String finalUrl = ensureEndsWith(new StringBuilder(baseUrl.length() + mapping.length() + 2).append(baseUrl), '/' as char)
+		final String finalUrl = ensureEndsWith(new StringBuilder(baseUrl.length() + mapping.length() + 2).append(baseUrl), '/' as char)
 			.append(mapping)
 			.append('/' as char)
 			.toString()

--- a/grails-app/services/asset/pipeline/grails/AssetProcessorService.groovy
+++ b/grails-app/services/asset/pipeline/grails/AssetProcessorService.groovy
@@ -47,14 +47,14 @@ class AssetProcessorService {
 
 	String getAssetPath(final String path, final ConfigObject conf = grailsApplication.config.grails.assets) {
 		final String relativePath = trimLeadingSlash(path)
-		return manifest?.getProperty(relativePath, relativePath) ?: relativePath
+		return manifest?.getProperty(relativePath) ?: relativePath
 	}
 
 
 	String getResolvedAssetPath(final String path, final ConfigObject conf = grailsApplication.config.grails.assets) {
 		final String relativePath = trimLeadingSlash(path)
 		if(manifest) {
-			manifest?.getProperty(relativePath)
+			manifest.getProperty(relativePath)
 		} else {
 			AssetHelper.fileForFullName(relativePath) != null ? relativePath : null
 		}

--- a/grails-app/services/asset/pipeline/grails/AssetProcessorService.groovy
+++ b/grails-app/services/asset/pipeline/grails/AssetProcessorService.groovy
@@ -47,7 +47,7 @@ class AssetProcessorService {
 
 	String getAssetPath(final String path, final ConfigObject conf = grailsApplication.config.grails.assets) {
 		final String relativePath = trimLeadingSlash(path)
-		return manifest?.getProperty(relativePath,relativePath) ?: relativePath
+		return manifest?.getProperty(relativePath, relativePath) ?: relativePath
 	}
 
 
@@ -58,7 +58,6 @@ class AssetProcessorService {
 		} else {
 			AssetHelper.fileForFullName(relativePath) != null ? relativePath : null
 		}
-
 	}
 
 
@@ -119,9 +118,9 @@ class AssetProcessorService {
 		}
 
 		def finalUrl = ensureEndsWith(new StringBuilder(baseUrl.length() + mapping.length() + 2).append(baseUrl), '/' as char)
-				.append(mapping)
-				.append('/' as char)
-				.toString()
+			.append(mapping)
+			.append('/' as char)
+			.toString()
 		return finalUrl
 	}
 

--- a/grails-app/services/asset/pipeline/grails/AssetProcessorService.groovy
+++ b/grails-app/services/asset/pipeline/grails/AssetProcessorService.groovy
@@ -1,14 +1,13 @@
 package asset.pipeline.grails
 
 
-import asset.pipeline.AssetHelper
+import asset.pipeline.AssetPaths
 import grails.util.Environment
 import javax.servlet.http.HttpServletRequest
 import org.codehaus.groovy.grails.web.mapping.DefaultLinkGenerator
 import org.codehaus.groovy.grails.web.servlet.mvc.GrailsWebRequest
 
 import static asset.pipeline.AssetPipelineConfigHolder.getConfig
-import static asset.pipeline.AssetPipelineConfigHolder.manifest
 import static asset.pipeline.grails.utils.net.HttpServletRequests.getBaseUrlWithScheme
 import static asset.pipeline.grails.utils.text.StringBuilders.ensureEndsWith
 import static asset.pipeline.utils.net.Urls.hasAuthority
@@ -21,27 +20,8 @@ class AssetProcessorService {
 
 
 	// <editor-fold desc="Grails-specific methods">
-	/**
-	 * Retrieves the asset path from the property [grails.assets.mapping] which is used by the url mapping and the
-	 * taglib.  The property cannot contain <code>/</code>, and must be one level deep
-	 *
-	 * @return the path
-	 * @throws IllegalArgumentException if the path contains <code>/</code>
-	 */
-	String getAssetMapping() {
-		final String mapping = config.mapping ?: 'assets'
-		if (mapping.contains('/')) {
-			throw new IllegalArgumentException(
-				'The property [grails.assets.mapping] can only be one level deep.  ' +
-				"For example, 'foo' and 'bar' would be acceptable values, but 'foo/bar' is not"
-			)
-		}
-		return mapping
-	}
-
-
 	String asset(final Map attrs, final DefaultLinkGenerator linkGenerator) {
-		String url = getResolvedAssetPath(attrs.file ?: attrs.src)
+		String url = AssetPaths.getResolvedAssetPath(attrs.file ?: attrs.src)
 
 		if (! url) {
 			return null
@@ -78,28 +58,28 @@ class AssetProcessorService {
 	// </editor-fold>
 
 
-	String getAssetPath(final String path) {
-		final String relativePath = trimLeadingSlash(path)
-		return manifest?.getProperty(relativePath) ?: relativePath
-	}
-
-
-	String getResolvedAssetPath(final String path) {
-		final String relativePath = trimLeadingSlash(path)
-		if(manifest) {
-			return manifest.getProperty(relativePath)
-		} else {
-			return AssetHelper.fileForFullName(relativePath) != null ? relativePath : null
+	// <editor-fold desc="Grails-config-property-specific methods that could be moved to core if core made to respect property">
+	/**
+	 * Retrieves the asset path from the property [grails.assets.mapping] which is used by the url mapping and the
+	 * taglib.  The property cannot contain <code>/</code>, and must be one level deep
+	 *
+	 * @return the path
+	 * @throws IllegalArgumentException if the path contains <code>/</code>
+	 */
+	String getAssetMapping() {
+		final String mapping = config.mapping ?: 'assets'
+		if(mapping.contains('/')) {
+			throw new IllegalArgumentException(
+				'The property [grails.assets.mapping] can only be one level deep.  ' +
+				"For example, 'foo' and 'bar' would be acceptable values, but 'foo/bar' is not"
+			)
 		}
+		return mapping
 	}
+	// </editor-fold>
 
 
-	boolean isAssetPath(final String path) {
-		final String relativePath = trimLeadingSlash(path)
-		return relativePath && (manifest ? manifest.getProperty(relativePath) : AssetHelper.fileForFullName(relativePath) != null)
-	}
-
-
+	// <editor-fold desc="HttpServletRequest-specific methods">
 	String getConfigBaseUrl(final HttpServletRequest req) {
 		final def url = config.url
 		if(url instanceof Closure) {
@@ -111,7 +91,7 @@ class AssetProcessorService {
 
 	String assetBaseUrl(final HttpServletRequest req, final String baseUrl) {
 		final String url = getConfigBaseUrl(req)
-		if (url) {
+		if(url) {
 			return url
 		}
 
@@ -124,12 +104,5 @@ class AssetProcessorService {
 
 		return finalUrl
 	}
-
-
-	private static String trimLeadingSlash(final String s) {
-		if(!s || s[0] != '/') {
-			return s
-		}
-		return s.substring(1)
-	}
+	// </editor-fold>
 }

--- a/grails-app/taglib/asset/pipeline/grails/AssetMethodTagLib.groovy
+++ b/grails-app/taglib/asset/pipeline/grails/AssetMethodTagLib.groovy
@@ -1,6 +1,8 @@
 package asset.pipeline.grails
 
 
+import asset.pipeline.AssetPaths
+
 import static org.apache.commons.lang.StringUtils.trimToEmpty
 
 
@@ -27,6 +29,6 @@ class AssetMethodTagLib {
 			baseUrl = trimToEmpty(grailsLinkGenerator.contextPath)
 		}
 
-		return assetProcessorService.assetBaseUrl(request, baseUrl) + assetProcessorService.getAssetPath(Objects.toString(src))
+		return assetProcessorService.assetBaseUrl(request, baseUrl) + AssetPaths.getAssetPath(Objects.toString(src))
 	}
 }

--- a/grails-app/taglib/asset/pipeline/grails/AssetMethodTagLib.groovy
+++ b/grails-app/taglib/asset/pipeline/grails/AssetMethodTagLib.groovy
@@ -1,7 +1,7 @@
 package asset.pipeline.grails
 
 
-import static asset.pipeline.grails.UrlBase.*
+import static org.apache.commons.lang.StringUtils.trimToEmpty
 
 
 class AssetMethodTagLib {
@@ -11,21 +11,22 @@ class AssetMethodTagLib {
 
 
 	def assetProcessorService
+	def grailsLinkGenerator
 
 
 	def assetPath = {final def attrs ->
-		final def     src
-		final UrlBase urlBase
+		final def    src
+		final String baseUrl
 
 		if (attrs instanceof Map) {
 			src     = attrs.src
-			urlBase = attrs.absolute ? SERVER_BASE_URL : CONTEXT_PATH
+			baseUrl = attrs.absolute ? (grailsLinkGenerator.serverBaseURL ?: '') : trimToEmpty(grailsLinkGenerator.contextPath)
 		}
 		else {
 			src     = attrs
-			urlBase = CONTEXT_PATH
+			baseUrl = trimToEmpty(grailsLinkGenerator.contextPath)
 		}
 
-		return assetProcessorService.assetBaseUrl(request, urlBase) + assetProcessorService.getAssetPath(Objects.toString(src))
+		return assetProcessorService.assetBaseUrl(request, baseUrl) + assetProcessorService.getAssetPath(Objects.toString(src))
 	}
 }

--- a/grails-app/taglib/asset/pipeline/grails/AssetMethodTagLib.groovy
+++ b/grails-app/taglib/asset/pipeline/grails/AssetMethodTagLib.groovy
@@ -6,7 +6,7 @@ import static org.apache.commons.lang.StringUtils.trimToEmpty
 
 class AssetMethodTagLib {
 
-	static namespace = 'g'
+	static namespace           = 'g'
 	static returnObjectForTags = ['assetPath']
 
 

--- a/grails-app/taglib/asset/pipeline/grails/AssetsTagLib.groovy
+++ b/grails-app/taglib/asset/pipeline/grails/AssetsTagLib.groovy
@@ -2,6 +2,7 @@ package asset.pipeline.grails
 
 
 import asset.pipeline.AssetHelper
+import asset.pipeline.AssetPaths
 import asset.pipeline.AssetPipeline
 import org.codehaus.groovy.grails.web.util.GrailsPrintWriter
 
@@ -14,7 +15,6 @@ class AssetsTagLib {
 	private static final LINE_BREAK = System.getProperty('line.separator') ?: '\n'
 
 
-	def assetProcessorService
 	def grailsApplication
 
 
@@ -136,7 +136,7 @@ class AssetsTagLib {
 	}
 
 	boolean isAssetPath(src) {
-		assetProcessorService.isAssetPath(src)
+		AssetPaths.isAssetPath(src)
 	}
 
 	private paramsToHtmlAttr(attrs) {

--- a/scripts/_AssetCompile.groovy
+++ b/scripts/_AssetCompile.groovy
@@ -27,19 +27,21 @@ target(assetCompile: 'Precompiles assets in the application as specified by the 
 
 	final Map<String, Object> assetConfig = [specs: []] // Additional Asset Specs (Asset File formats) to process
 
-	assetPipelineConfigHolder.config = config.grails.assets
+	final ConfigObject grailsConfig = config.grails.assets
+
+	assetPipelineConfigHolder.config = grailsConfig
 	assetPipelineConfigHolder.config.cacheLocation = 'target/.asscache'
 	event('AssetPrecompileStart', [assetConfig])
 
-	assetConfig.minifyJs         = config.grails.assets.containsKey('minifyJs')         ? config.grails.assets.minifyJs  : (argsMap.containsKey('minifyJs')  ? argsMap.minifyJs  == 'true' : true)
-	assetConfig.minifyCss        = config.grails.assets.containsKey('minifyCss')        ? config.grails.assets.minifyCss : (argsMap.containsKey('minifyCss') ? argsMap.minifyCss == 'true' : true)
-	assetConfig.minifyOptions    = config.grails.assets.minifyOptions
+	assetConfig.minifyJs         = grailsConfig.containsKey('minifyJs')         ? grailsConfig.minifyJs  : (argsMap.containsKey('minifyJs')  ? argsMap.minifyJs  == 'true' : true)
+	assetConfig.minifyCss        = grailsConfig.containsKey('minifyCss')        ? grailsConfig.minifyCss : (argsMap.containsKey('minifyCss') ? argsMap.minifyCss == 'true' : true)
+	assetConfig.minifyOptions    = grailsConfig.minifyOptions
 	assetConfig.compileDir       = "${basedir}/target/assets"
-	assetConfig.enableGzip       = config.grails.assets.enableGzip
-	assetConfig.excludesGzip     = config.grails.assets.excludesGzip
-	assetConfig.enableSourceMaps = config.grails.assets.containsKey('enableSourceMaps') ? config.grails.assets.enableSourceMaps : true
-	assetConfig.skipNonDigests   = config.grails.assets.containsKey('skipNonDigests')   ? config.grails.assets.skipNonDigests   : true
-	assetConfig.enableDigests    = config.grails.assets.containsKey('enableDigests')    ? config.grails.assets.enableDigests    : true
+	assetConfig.enableGzip       = grailsConfig.enableGzip
+	assetConfig.excludesGzip     = grailsConfig.excludesGzip
+	assetConfig.enableSourceMaps = grailsConfig.containsKey('enableSourceMaps') ? grailsConfig.enableSourceMaps : true
+	assetConfig.skipNonDigests   = grailsConfig.containsKey('skipNonDigests')   ? grailsConfig.skipNonDigests   : true
+	assetConfig.enableDigests    = grailsConfig.containsKey('enableDigests')    ? grailsConfig.enableDigests    : true
 
 	// Add Resolvers for Grails
 	assetPipelineConfigHolder.registerResolver(fileSystemAssetResolver.newInstance('application', "${basedir}/grails-app/assets"))
@@ -71,11 +73,11 @@ target(assetCompile: 'Precompiles assets in the application as specified by the 
 
 	final def assetCompiler = assetCompilerClass.newInstance(assetConfig + [compileDir: "${basedir}/target/assets", classLoader: classLoader], eventListener)
 
-	assetCompiler.excludeRules.default = config.grails.assets.excludes
-	assetCompiler.includeRules.default = config.grails.assets.includes
+	assetCompiler.excludeRules.default = grailsConfig.excludes
+	assetCompiler.includeRules.default = grailsConfig.includes
 
 	// Initialize Exclude/Include Rules
-	config.grails.assets.plugin.each { final pluginName, final value ->
+	grailsConfig.plugin.each { final pluginName, final value ->
 		if (value.excludes) {
 			assetCompiler.excludeRules[pluginName] = value.excludes
 		}

--- a/scripts/_AssetCompile.groovy
+++ b/scripts/_AssetCompile.groovy
@@ -7,7 +7,7 @@ includeTargets << grailsScript("_GrailsBootstrap")
 target(assetClean: "Cleans Compiled Assets Directory") {
 	// Clear compiled assets folder
 	println "Asset Precompiler Args ${argsMap}"
-	def assetDir = new File(argsMap.target ?: "target/assets")
+	final def assetDir = new File(argsMap.target ?: "target/assets")
 	if (assetDir.exists()) {
 		assetDir.deleteDir()
 	}
@@ -16,15 +16,15 @@ target(assetClean: "Cleans Compiled Assets Directory") {
 target(assetCompile: "Precompiles assets in the application as specified by the precompile glob!") {
 	depends(configureProxy,compile)
 
-	def assetPipelineConfigHolder = classLoader.loadClass('asset.pipeline.AssetPipelineConfigHolder')
-	def defaultResourceLoader     = classLoader.loadClass('org.springframework.core.io.DefaultResourceLoader').newInstance(classLoader)
-	def fileSystemAssetResolver   = classLoader.loadClass('asset.pipeline.fs.FileSystemAssetResolver')
-	def jarAssetResolver          = classLoader.loadClass('asset.pipeline.fs.JarAssetResolver')
-	def assetHelper               = classLoader.loadClass('asset.pipeline.AssetHelper')
-	def assetCompilerClass        = classLoader.loadClass('asset.pipeline.AssetCompiler')
-	def directiveProcessorClass   = classLoader.loadClass('asset.pipeline.DirectiveProcessor')
+	final def assetPipelineConfigHolder = classLoader.loadClass('asset.pipeline.AssetPipelineConfigHolder')
+	final def defaultResourceLoader     = classLoader.loadClass('org.springframework.core.io.DefaultResourceLoader').newInstance(classLoader)
+	final def fileSystemAssetResolver   = classLoader.loadClass('asset.pipeline.fs.FileSystemAssetResolver')
+	final def jarAssetResolver          = classLoader.loadClass('asset.pipeline.fs.JarAssetResolver')
+	final def assetHelper               = classLoader.loadClass('asset.pipeline.AssetHelper')
+	final def assetCompilerClass        = classLoader.loadClass('asset.pipeline.AssetCompiler')
+	final def directiveProcessorClass   = classLoader.loadClass('asset.pipeline.DirectiveProcessor')
 
-	def assetConfig               = [specs:[]] //Additional Asset Specs (Asset File formats) that we want to process.
+	final def assetConfig               = [specs:[]] //Additional Asset Specs (Asset File formats) that we want to process.
 	assetPipelineConfigHolder.config = config.grails.assets
 	assetPipelineConfigHolder.config.cacheLocation = "target/.asscache"
 	event("AssetPrecompileStart", [assetConfig])
@@ -42,14 +42,14 @@ target(assetCompile: "Precompiles assets in the application as specified by the 
 	//Add Resolvers for Grails
 	assetPipelineConfigHolder.registerResolver(fileSystemAssetResolver.newInstance('application', "${basedir}/grails-app/assets"))
 
-	for (plugin in GrailsPluginUtils.pluginInfos) {
+	for (final plugin in GrailsPluginUtils.pluginInfos) {
 		def assetPath    = [plugin.pluginDir.getPath(), "grails-app", "assets"].join(File.separator)
 		def fallbackPath = [plugin.pluginDir.getPath(), "web-app"].join(File.separator)
 		assetPipelineConfigHolder.registerResolver(fileSystemAssetResolver.newInstance(plugin.name, assetPath))
 		assetPipelineConfigHolder.registerResolver(fileSystemAssetResolver.newInstance(plugin.name, fallbackPath, true))
 	}
 
-	grailsSettings.runtimeDependencies.each { dep ->
+	grailsSettings.runtimeDependencies.each { final dep ->
 		if (dep.name.endsWith('.jar')) {
 			assetPipelineConfigHolder.registerResolver(jarAssetResolver.newInstance(dep.name, dep.path, 'META-INF/assets'))
 			assetPipelineConfigHolder.registerResolver(jarAssetResolver.newInstance(dep.name, dep.path, 'META-INF/static'))
@@ -57,7 +57,7 @@ target(assetCompile: "Precompiles assets in the application as specified by the 
 		}
 	}
 
-	grailsSettings.providedDependencies.each { dep ->
+	grailsSettings.providedDependencies.each { final dep ->
 		if (dep.name.endsWith('.jar')) {
 			assetPipelineConfigHolder.registerResolver(jarAssetResolver.newInstance(dep.name, dep.path, 'META-INF/assets'))
 			assetPipelineConfigHolder.registerResolver(jarAssetResolver.newInstance(dep.name, dep.path, 'META-INF/static'))
@@ -67,13 +67,13 @@ target(assetCompile: "Precompiles assets in the application as specified by the 
 
 	event("StatusUpdate", ["Precompiling Assets!"])
 
-	def assetCompiler = assetCompilerClass.newInstance(assetConfig + [compileDir: "${basedir}/target/assets", classLoader: classLoader],  eventListener)
+	final def assetCompiler = assetCompilerClass.newInstance(assetConfig + [compileDir: "${basedir}/target/assets", classLoader: classLoader],  eventListener)
 
 	assetCompiler.excludeRules.default = config.grails.assets.excludes
 	assetCompiler.includeRules.default = config.grails.assets.includes
 
 	// Initialize Exclude/Include Rules
-	config.grails.assets.plugin.each { pluginName, value ->
+	config.grails.assets.plugin.each { final pluginName, final value ->
 		if (value.excludes) {
 			assetCompiler.excludeRules[pluginName] = value.excludes
 		}

--- a/scripts/_AssetCompile.groovy
+++ b/scripts/_AssetCompile.groovy
@@ -2,19 +2,19 @@ import org.codehaus.groovy.grails.plugins.GrailsPluginInfo
 import org.codehaus.groovy.grails.plugins.GrailsPluginUtils
 
 
-includeTargets << grailsScript("_PackagePlugins")
-includeTargets << grailsScript("_GrailsBootstrap")
+includeTargets << grailsScript('_PackagePlugins')
+includeTargets << grailsScript('_GrailsBootstrap')
 
-target(assetClean: "Cleans Compiled Assets Directory") {
+target(assetClean: 'Cleans Compiled Assets Directory') {
 	// Clear compiled assets folder
 	println "Asset Precompiler Args ${argsMap}"
-	final File assetDir = new File(argsMap.target ?: "target/assets")
+	final File assetDir = new File(argsMap.target ?: 'target/assets')
 	if (assetDir.exists()) {
 		assetDir.deleteDir()
 	}
 }
 
-target(assetCompile: "Precompiles assets in the application as specified by the precompile glob!") {
+target(assetCompile: 'Precompiles assets in the application as specified by the precompile glob!') {
 	depends(configureProxy,compile)
 
 	final Class<?> assetPipelineConfigHolder = classLoader.loadClass('asset.pipeline.AssetPipelineConfigHolder')
@@ -28,8 +28,8 @@ target(assetCompile: "Precompiles assets in the application as specified by the 
 	final Map<String, Object> assetConfig = [specs: []] // Additional Asset Specs (Asset File formats) to process
 
 	assetPipelineConfigHolder.config = config.grails.assets
-	assetPipelineConfigHolder.config.cacheLocation = "target/.asscache"
-	event("AssetPrecompileStart", [assetConfig])
+	assetPipelineConfigHolder.config.cacheLocation = 'target/.asscache'
+	event('AssetPrecompileStart', [assetConfig])
 
 	assetConfig.minifyJs         = config.grails.assets.containsKey('minifyJs')         ? config.grails.assets.minifyJs  : (argsMap.containsKey('minifyJs')  ? argsMap.minifyJs  == 'true' : true)
 	assetConfig.minifyCss        = config.grails.assets.containsKey('minifyCss')        ? config.grails.assets.minifyCss : (argsMap.containsKey('minifyCss') ? argsMap.minifyCss == 'true' : true)
@@ -45,8 +45,8 @@ target(assetCompile: "Precompiles assets in the application as specified by the 
 	assetPipelineConfigHolder.registerResolver(fileSystemAssetResolver.newInstance('application', "${basedir}/grails-app/assets"))
 
 	for (final GrailsPluginInfo plugin in GrailsPluginUtils.pluginInfos) {
-		final String assetPath    = [plugin.pluginDir.getPath(), "grails-app", "assets"].join(File.separator)
-		final String fallbackPath = [plugin.pluginDir.getPath(), "web-app"].join(File.separator)
+		final String assetPath    = [plugin.pluginDir.getPath(), 'grails-app', 'assets'].join(File.separator)
+		final String fallbackPath = [plugin.pluginDir.getPath(), 'web-app'].join(File.separator)
 		assetPipelineConfigHolder.registerResolver(fileSystemAssetResolver.newInstance(plugin.name, assetPath))
 		assetPipelineConfigHolder.registerResolver(fileSystemAssetResolver.newInstance(plugin.name, fallbackPath, true))
 	}
@@ -67,7 +67,7 @@ target(assetCompile: "Precompiles assets in the application as specified by the 
 		}
 	}
 
-	event("StatusUpdate", ["Precompiling Assets!"])
+	event('StatusUpdate', ['Precompiling Assets!'])
 
 	final def assetCompiler = assetCompilerClass.newInstance(assetConfig + [compileDir: "${basedir}/target/assets", classLoader: classLoader], eventListener)
 
@@ -84,5 +84,5 @@ target(assetCompile: "Precompiles assets in the application as specified by the 
 		}
 	}
 	assetCompiler.compile()
-	event("AssetPrecompileComplete", [assetConfig])
+	event('AssetPrecompileComplete', [assetConfig])
 }

--- a/scripts/_AssetCompile.groovy
+++ b/scripts/_AssetCompile.groovy
@@ -15,7 +15,7 @@ target(assetClean: 'Cleans Compiled Assets Directory') {
 }
 
 target(assetCompile: 'Precompiles assets in the application as specified by the precompile glob!') {
-	depends(configureProxy,compile)
+	depends(configureProxy, compile)
 
 	final Class<?> assetPipelineConfigHolder = classLoader.loadClass('asset.pipeline.AssetPipelineConfigHolder')
 	final def      defaultResourceLoader     = classLoader.loadClass('org.springframework.core.io.DefaultResourceLoader').newInstance(classLoader)

--- a/scripts/_AssetCompile.groovy
+++ b/scripts/_AssetCompile.groovy
@@ -30,7 +30,9 @@ target(assetCompile: 'Precompiles assets in the application as specified by the 
 	final ConfigObject grailsConfig = config.grails.assets
 
 	assetPipelineConfigHolder.config = grailsConfig
-	assetPipelineConfigHolder.config.cacheLocation = 'target/.asscache'
+
+	grailsConfig.cacheLocation = 'target/.asscache'
+
 	event('AssetPrecompileStart', [assetConfig])
 
 	assetConfig.minifyJs         = grailsConfig.containsKey('minifyJs')         ? grailsConfig.minifyJs  : (argsMap.containsKey('minifyJs')  ? argsMap.minifyJs  == 'true' : true)

--- a/scripts/_AssetCompile.groovy
+++ b/scripts/_AssetCompile.groovy
@@ -40,32 +40,32 @@ target(assetCompile: "Precompiles assets in the application as specified by the 
 	assetConfig.enableDigests    = config.grails.assets.containsKey('enableDigests')    ? config.grails.assets.enableDigests    : true
 
 	//Add Resolvers for Grails
-	assetPipelineConfigHolder.registerResolver(fileSystemAssetResolver.newInstance('application',"${basedir}/grails-app/assets"))
+	assetPipelineConfigHolder.registerResolver(fileSystemAssetResolver.newInstance('application', "${basedir}/grails-app/assets"))
 
 	for (plugin in GrailsPluginUtils.pluginInfos) {
 		def assetPath    = [plugin.pluginDir.getPath(), "grails-app", "assets"].join(File.separator)
 		def fallbackPath = [plugin.pluginDir.getPath(), "web-app"].join(File.separator)
-		assetPipelineConfigHolder.registerResolver(fileSystemAssetResolver.newInstance(plugin.name,assetPath))
-		assetPipelineConfigHolder.registerResolver(fileSystemAssetResolver.newInstance(plugin.name,fallbackPath,true))
+		assetPipelineConfigHolder.registerResolver(fileSystemAssetResolver.newInstance(plugin.name, assetPath))
+		assetPipelineConfigHolder.registerResolver(fileSystemAssetResolver.newInstance(plugin.name, fallbackPath, true))
 	}
 
 	grailsSettings.runtimeDependencies.each { dep ->
 		if (dep.name.endsWith('.jar')) {
-			assetPipelineConfigHolder.registerResolver(jarAssetResolver.newInstance(dep.name,dep.path,'META-INF/assets'))
-			assetPipelineConfigHolder.registerResolver(jarAssetResolver.newInstance(dep.name,dep.path,'META-INF/static'))
-			assetPipelineConfigHolder.registerResolver(jarAssetResolver.newInstance(dep.name,dep.path,'META-INF/resources'))
+			assetPipelineConfigHolder.registerResolver(jarAssetResolver.newInstance(dep.name, dep.path, 'META-INF/assets'))
+			assetPipelineConfigHolder.registerResolver(jarAssetResolver.newInstance(dep.name, dep.path, 'META-INF/static'))
+			assetPipelineConfigHolder.registerResolver(jarAssetResolver.newInstance(dep.name, dep.path, 'META-INF/resources'))
 		}
 	}
 
 	grailsSettings.providedDependencies.each { dep ->
 		if (dep.name.endsWith('.jar')) {
-			assetPipelineConfigHolder.registerResolver(jarAssetResolver.newInstance(dep.name,dep.path,'META-INF/assets'))
-			assetPipelineConfigHolder.registerResolver(jarAssetResolver.newInstance(dep.name,dep.path,'META-INF/static'))
-			assetPipelineConfigHolder.registerResolver(jarAssetResolver.newInstance(dep.name,dep.path,'META-INF/resources'))
+			assetPipelineConfigHolder.registerResolver(jarAssetResolver.newInstance(dep.name, dep.path, 'META-INF/assets'))
+			assetPipelineConfigHolder.registerResolver(jarAssetResolver.newInstance(dep.name, dep.path, 'META-INF/static'))
+			assetPipelineConfigHolder.registerResolver(jarAssetResolver.newInstance(dep.name, dep.path, 'META-INF/resources'))
 		}
 	}
 
-	event("StatusUpdate",["Precompiling Assets!"])
+	event("StatusUpdate", ["Precompiling Assets!"])
 
 	def assetCompiler = assetCompilerClass.newInstance(assetConfig + [compileDir: "${basedir}/target/assets", classLoader: classLoader],  eventListener)
 

--- a/src/groovy/asset/pipeline/grails/AssetPipelineFilter.groovy
+++ b/src/groovy/asset/pipeline/grails/AssetPipelineFilter.groovy
@@ -25,15 +25,18 @@ class AssetPipelineFilter implements Filter {
 	def warDeployed
 
 
+	@Override
 	void init(FilterConfig config) throws ServletException {
 		applicationContext = WebApplicationContextUtils.getWebApplicationContext(config.servletContext)
 		servletContext = config.servletContext
 		warDeployed = Environment.isWarDeployed()
 	}
 
+	@Override
 	void destroy() {
 	}
 
+	@Override
 	void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
 		def mapping = applicationContext.assetProcessorService.assetMapping
 

--- a/src/groovy/asset/pipeline/grails/AssetPipelineFilter.groovy
+++ b/src/groovy/asset/pipeline/grails/AssetPipelineFilter.groovy
@@ -16,7 +16,7 @@ import java.text.SimpleDateFormat
 class AssetPipelineFilter implements Filter {
 	public static final String HTTP_DATE_FORMAT = "EEE, dd MMM yyyy HH:mm:ss zzz"
 
-	public static final ProductionAssetCache fileCache = new ProductionAssetCache();
+	public static final ProductionAssetCache fileCache = new ProductionAssetCache()
 
 	def applicationContext
 	def servletContext
@@ -82,12 +82,12 @@ class AssetPipelineFilter implements Filter {
 						response.setContentType(format)
 						def inputStream
 						try {
-							byte[] buffer = new byte[102400];
-							int len;
+							byte[] buffer = new byte[102400]
+							int len
 							inputStream = file.inputStream
 							def out = response.outputStream
 							while ((len = inputStream.read(buffer)) != -1) {
-								out.write(buffer, 0, len);
+								out.write(buffer, 0, len)
 							}
 							response.flushBuffer()
 						} catch(e) {
@@ -147,12 +147,12 @@ class AssetPipelineFilter implements Filter {
 						response.setHeader('Content-Length', file.contentLength().toString())
 						def inputStream
 						try {
-							byte[] buffer = new byte[102400];
-							int len;
+							byte[] buffer = new byte[102400]
+							int len
 							inputStream = file.inputStream
 							def out = response.outputStream
 							while ((len = inputStream.read(buffer)) != -1) {
-								out.write(buffer, 0, len);
+								out.write(buffer, 0, len)
 							}
 							response.flushBuffer()
 						} catch(e) {
@@ -206,8 +206,8 @@ class AssetPipelineFilter implements Filter {
 	boolean hasNotChanged(String ifModifiedSince, Date date) {
 		boolean hasNotChanged = false
 		if (ifModifiedSince) {
-			final SimpleDateFormat sdf = new SimpleDateFormat(HTTP_DATE_FORMAT);
-			sdf.setTimeZone(TimeZone.getTimeZone("GMT"));
+			final SimpleDateFormat sdf = new SimpleDateFormat(HTTP_DATE_FORMAT)
+			sdf.setTimeZone(TimeZone.getTimeZone("GMT"))
 			try {
 				hasNotChanged = new Date(file?.lastModified()) <= sdf.parse(ifModifiedSince)
 			} catch (Exception e) {
@@ -217,8 +217,8 @@ class AssetPipelineFilter implements Filter {
 		return hasNotChanged
 	}
 	private String getLastModifiedDate(Date date) {
-		final SimpleDateFormat sdf = new SimpleDateFormat(HTTP_DATE_FORMAT);
-		sdf.setTimeZone(TimeZone.getTimeZone("GMT"));
+		final SimpleDateFormat sdf = new SimpleDateFormat(HTTP_DATE_FORMAT)
+		sdf.setTimeZone(TimeZone.getTimeZone("GMT"))
 		String lastModifiedDateTimeString = sdf.format(new Date())
 		try {
 			lastModifiedDateTimeString = sdf.format(date)

--- a/src/groovy/asset/pipeline/grails/AssetPipelineFilter.groovy
+++ b/src/groovy/asset/pipeline/grails/AssetPipelineFilter.groovy
@@ -98,7 +98,7 @@ class AssetPipelineFilter implements Filter {
 							response.flushBuffer()
 						} catch(e) {
 							log.debug("File Transfer Aborted (Probably by the user)", e)
-						}finally {
+						} finally {
 							try { inputStream?.close()} catch(ie){/*silent close fail*/}
 						}
 					} else {

--- a/src/groovy/asset/pipeline/grails/AssetPipelineFilter.groovy
+++ b/src/groovy/asset/pipeline/grails/AssetPipelineFilter.groovy
@@ -15,9 +15,9 @@ import java.text.SimpleDateFormat
 @Slf4j
 class AssetPipelineFilter implements Filter {
 
-	public static final String HTTP_DATE_FORMAT = "EEE, dd MMM yyyy HH:mm:ss zzz"
+	static final String HTTP_DATE_FORMAT = "EEE, dd MMM yyyy HH:mm:ss zzz"
 
-	public static final ProductionAssetCache fileCache = new ProductionAssetCache()
+	static final ProductionAssetCache fileCache = new ProductionAssetCache()
 
 
 	def applicationContext

--- a/src/groovy/asset/pipeline/grails/AssetPipelineFilter.groovy
+++ b/src/groovy/asset/pipeline/grails/AssetPipelineFilter.groovy
@@ -1,5 +1,6 @@
 package asset.pipeline.grails
 
+
 import asset.pipeline.AssetPipeline
 import asset.pipeline.AssetPipelineConfigHolder
 import asset.pipeline.AssetPipelineResponseBuilder
@@ -8,13 +9,13 @@ import groovy.util.logging.Slf4j
 import org.springframework.web.context.support.WebApplicationContextUtils
 
 import javax.servlet.*
-import java.util.TimeZone
 import java.text.SimpleDateFormat
+
 
 @Slf4j
 class AssetPipelineFilter implements Filter {
 	public static final String HTTP_DATE_FORMAT = "EEE, dd MMM yyyy HH:mm:ss zzz"
-	
+
 	public static final ProductionAssetCache fileCache = new ProductionAssetCache();
 
 	def applicationContext
@@ -64,7 +65,7 @@ class AssetPipelineFilter implements Filter {
 					if(responseBuilder.statusCode) {
 						response.status = responseBuilder.statusCode
 					}
-					
+
 					if(responseBuilder.statusCode != 304) {
 						def acceptsEncoding = request.getHeader("Accept-Encoding")
 						if(acceptsEncoding?.split(",")?.contains("gzip") && attributeCache.gzipExists()) {
@@ -101,7 +102,7 @@ class AssetPipelineFilter implements Filter {
 					response.status = 404
 					response.flushBuffer()
 				}
-				
+
 			} else {
 				def file = applicationContext.getResource("assets/${fileUri}")
 				if(!file.exists()) {
@@ -120,7 +121,7 @@ class AssetPipelineFilter implements Filter {
 					if(responseBuilder.statusCode) {
 						response.status = responseBuilder.statusCode
 					}
-					
+
 
 					def gzipFile = applicationContext.getResource("assets/${fileUri}.gz")
 					if(!gzipFile.exists()) {

--- a/src/groovy/asset/pipeline/grails/AssetPipelineFilter.groovy
+++ b/src/groovy/asset/pipeline/grails/AssetPipelineFilter.groovy
@@ -14,15 +14,18 @@ import java.text.SimpleDateFormat
 
 @Slf4j
 class AssetPipelineFilter implements Filter {
+
 	public static final String HTTP_DATE_FORMAT = "EEE, dd MMM yyyy HH:mm:ss zzz"
 
 	public static final ProductionAssetCache fileCache = new ProductionAssetCache()
 
+
 	def applicationContext
 	def servletContext
 	def warDeployed
-	void init(FilterConfig config) throws ServletException {
 
+
+	void init(FilterConfig config) throws ServletException {
 		applicationContext = WebApplicationContextUtils.getWebApplicationContext(config.servletContext)
 		servletContext = config.servletContext
 		warDeployed = Environment.isWarDeployed()
@@ -54,10 +57,10 @@ class AssetPipelineFilter implements Filter {
 			if(attributeCache) {
 				if(attributeCache.exists()) {
 					def file = attributeCache.resource
-					def responseBuilder = new AssetPipelineResponseBuilder(fileUri,request.getHeader('If-None-Match'), request.getHeader('If-Modified-Since'))
+					def responseBuilder = new AssetPipelineResponseBuilder(fileUri, request.getHeader('If-None-Match'), request.getHeader('If-Modified-Since'))
 					response.setHeader('Last-Modified', getLastModifiedDate(attributeCache.getLastModified()))
 					responseBuilder.headers.each { header ->
-						response.setHeader(header.key,header.value)
+						response.setHeader(header.key, header.value)
 					}
 					if (hasNotChanged(responseBuilder.ifModifiedSinceHeader, attributeCache.getLastModified())) {
 						responseBuilder.statusCode = 304
@@ -70,7 +73,7 @@ class AssetPipelineFilter implements Filter {
 						def acceptsEncoding = request.getHeader("Accept-Encoding")
 						if(acceptsEncoding?.split(",")?.contains("gzip") && attributeCache.gzipExists()) {
 							file = attributeCache.getGzipResource()
-							response.setHeader('Content-Encoding','gzip')
+							response.setHeader('Content-Encoding', 'gzip')
 							response.setHeader('Content-Length', attributeCache.getGzipFileSize().toString())
 						} else {
 							response.setHeader('Content-Length', attributeCache.getFileSize().toString())
@@ -91,7 +94,7 @@ class AssetPipelineFilter implements Filter {
 							}
 							response.flushBuffer()
 						} catch(e) {
-							log.debug("File Transfer Aborted (Probably by the user)",e)
+							log.debug("File Transfer Aborted (Probably by the user)", e)
 						}finally {
 							try { inputStream?.close()} catch(ie){/*silent close fail*/}
 						}
@@ -102,7 +105,6 @@ class AssetPipelineFilter implements Filter {
 					response.status = 404
 					response.flushBuffer()
 				}
-
 			} else {
 				def file = applicationContext.getResource("assets/${fileUri}")
 				if(!file.exists()) {
@@ -110,18 +112,17 @@ class AssetPipelineFilter implements Filter {
 				}
 
 				if(file.exists()) {
-					def responseBuilder = new AssetPipelineResponseBuilder(fileUri,request.getHeader('If-None-Match'), request.getHeader('If-Modified-Since'))
+					def responseBuilder = new AssetPipelineResponseBuilder(fileUri, request.getHeader('If-None-Match'), request.getHeader('If-Modified-Since'))
 					response.setHeader('Last-Modified', getLastModifiedDate(new Date(file.lastModified())))
 					if (hasNotChanged(responseBuilder.ifModifiedSinceHeader, new Date(file.lastModified()))) {
 						responseBuilder.statusCode = 304
 					}
 					responseBuilder.headers.each { header ->
-						response.setHeader(header.key,header.value)
+						response.setHeader(header.key, header.value)
 					}
 					if(responseBuilder.statusCode) {
 						response.status = responseBuilder.statusCode
 					}
-
 
 					def gzipFile = applicationContext.getResource("assets/${fileUri}.gz")
 					if(!gzipFile.exists()) {
@@ -137,7 +138,7 @@ class AssetPipelineFilter implements Filter {
 						if(acceptsEncoding?.split(",")?.contains("gzip")) {
 							if(gzipFile.exists()) {
 								file = gzipFile
-								response.setHeader('Content-Encoding','gzip')
+								response.setHeader('Content-Encoding', 'gzip')
 							}
 						}
 						if(encoding) {
@@ -156,7 +157,7 @@ class AssetPipelineFilter implements Filter {
 							}
 							response.flushBuffer()
 						} catch(e) {
-							log.debug("File Transfer Aborted (Probably by the user)",e)
+							log.debug("File Transfer Aborted (Probably by the user)", e)
 						} finally {
 							try { inputStream?.close()} catch(ie){/*silent close fail*/}
 						}
@@ -173,13 +174,12 @@ class AssetPipelineFilter implements Filter {
 		} else {
 			def fileContents
 			if(request.getParameter('compile') == 'false') {
-				fileContents = AssetPipeline.serveUncompiledAsset(fileUri,format, null, encoding)
+				fileContents = AssetPipeline.serveUncompiledAsset(fileUri, format, null, encoding)
 			} else {
-				fileContents = AssetPipeline.serveAsset(fileUri,format, null, encoding)
+				fileContents = AssetPipeline.serveAsset(fileUri, format, null, encoding)
 			}
 
 			if (fileContents != null) {
-
 				response.setHeader("Cache-Control", "no-cache, no-store, must-revalidate") // HTTP 1.1.
 				response.setHeader("Pragma", "no-cache") // HTTP 1.0.
 				response.setDateHeader("Expires", 0) // Proxies.
@@ -190,7 +190,7 @@ class AssetPipelineFilter implements Filter {
 					response.outputStream << fileContents
 					response.flushBuffer()
 				} catch(e) {
-					log.debug("File Transfer Aborted (Probably by the user)",e)
+					log.debug("File Transfer Aborted (Probably by the user)", e)
 				}
 			} else {
 				response.status = 404
@@ -198,11 +198,11 @@ class AssetPipelineFilter implements Filter {
 			}
 		}
 
-
 		if (!response.committed) {
 			chain.doFilter(request, response)
 		}
 	}
+
 	boolean hasNotChanged(String ifModifiedSince, Date date) {
 		boolean hasNotChanged = false
 		if (ifModifiedSince) {
@@ -216,6 +216,7 @@ class AssetPipelineFilter implements Filter {
 		}
 		return hasNotChanged
 	}
+
 	private String getLastModifiedDate(Date date) {
 		final SimpleDateFormat sdf = new SimpleDateFormat(HTTP_DATE_FORMAT)
 		sdf.setTimeZone(TimeZone.getTimeZone("GMT"))
@@ -228,5 +229,4 @@ class AssetPipelineFilter implements Filter {
 
 		return lastModifiedDateTimeString
 	}
-
 }

--- a/src/groovy/asset/pipeline/grails/AssetPipelineFilter.groovy
+++ b/src/groovy/asset/pipeline/grails/AssetPipelineFilter.groovy
@@ -47,14 +47,16 @@ class AssetPipelineFilter implements Filter {
 		final String baseAssetUrl = request.contextPath == "/" ? "/$mapping" : "${request.contextPath}/${mapping}"
 		final String format       = servletContext.getMimeType(fileUri)
 		final String encoding     = request.getParameter('encoding') ?: request.getCharacterEncoding()
+
 		if(fileUri.startsWith(baseAssetUrl)) {
 			fileUri = fileUri.substring(baseAssetUrl.length())
 		}
+
 		if(warDeployed) {
 			final Properties manifest = AssetPipelineConfigHolder.manifest
 			String manifestPath = fileUri
 			if(fileUri.startsWith('/')) {
-			  manifestPath = fileUri.substring(1) //Omit forward slash
+				manifestPath = fileUri.substring(1) //Omit forward slash
 			}
 			fileUri = manifest?.getProperty(manifestPath, manifestPath)
 
@@ -68,6 +70,7 @@ class AssetPipelineFilter implements Filter {
 						request.getHeader('If-None-Match'),
 						request.getHeader('If-Modified-Since')
 					)
+
 					response.setHeader('Last-Modified', getLastModifiedDate(attributeCache.getLastModified()))
 					responseBuilder.headers.each { final header ->
 						response.setHeader(header.key, header.value)
@@ -75,6 +78,7 @@ class AssetPipelineFilter implements Filter {
 					if (hasNotChanged(responseBuilder.ifModifiedSinceHeader, attributeCache.getLastModified())) {
 						responseBuilder.statusCode = 304
 					}
+
 					if(responseBuilder.statusCode) {
 						response.status = responseBuilder.statusCode
 					}
@@ -99,14 +103,14 @@ class AssetPipelineFilter implements Filter {
 							int len
 							inputStream = file.inputStream
 							final ServletOutputStream out = response.outputStream
-							while ((len = inputStream.read(buffer)) != -1) {
+							while((len = inputStream.read(buffer)) != -1) {
 								out.write(buffer, 0, len)
 							}
 							response.flushBuffer()
 						} catch(final e) {
 							log.debug("File Transfer Aborted (Probably by the user)", e)
 						} finally {
-							try { inputStream?.close()} catch(final ie){/*silent close fail*/}
+							try { inputStream?.close() } catch(final ie) { /* silent fail */ }
 						}
 					} else {
 						response.flushBuffer()
@@ -127,6 +131,7 @@ class AssetPipelineFilter implements Filter {
 						request.getHeader('If-None-Match'),
 						request.getHeader('If-Modified-Since')
 					)
+
 					response.setHeader('Last-Modified', getLastModifiedDate(new Date(file.lastModified())))
 					if (hasNotChanged(responseBuilder.ifModifiedSinceHeader, new Date(file.lastModified()))) {
 						responseBuilder.statusCode = 304
@@ -168,21 +173,21 @@ class AssetPipelineFilter implements Filter {
 							response.setCharacterEncoding(encoding)
 						}
 						response.setContentType(format)
-						response.setHeader('Content-Length', file.contentLength().toString())
+						response.setHeader('Content-Length', String.valueOf(file.contentLength()))
 						final InputStream inputStream
 						try {
 							final byte[] buffer = new byte[102400]
 							int len
 							inputStream = file.inputStream
 							final ServletOutputStream out = response.outputStream
-							while ((len = inputStream.read(buffer)) != -1) {
+							while((len = inputStream.read(buffer)) != -1) {
 								out.write(buffer, 0, len)
 							}
 							response.flushBuffer()
 						} catch(final e) {
 							log.debug("File Transfer Aborted (Probably by the user)", e)
 						} finally {
-							try { inputStream?.close()} catch(final ie){/*silent close fail*/}
+							try { inputStream?.close() } catch(final ie) { /* silent fail */ }
 						}
 					} else {
 						response.flushBuffer()
@@ -202,11 +207,11 @@ class AssetPipelineFilter implements Filter {
 				fileContents = AssetPipeline.serveAsset(fileUri, format, null, encoding)
 			}
 
-			if (fileContents != null) {
+			if(fileContents != null) {
 				response.setHeader("Cache-Control", "no-cache, no-store, must-revalidate") // HTTP 1.1.
 				response.setHeader("Pragma", "no-cache") // HTTP 1.0.
 				response.setDateHeader("Expires", 0) // Proxies.
-				response.setHeader('Content-Length', fileContents.size().toString())
+				response.setHeader('Content-Length', String.valueOf(fileContents.size()))
 
 				response.setContentType(format)
 				try {
@@ -221,7 +226,7 @@ class AssetPipelineFilter implements Filter {
 			}
 		}
 
-		if (!response.committed) {
+		if(!response.committed) {
 			chain.doFilter(request, response)
 		}
 	}

--- a/src/groovy/asset/pipeline/grails/AssetResourceLocator.groovy
+++ b/src/groovy/asset/pipeline/grails/AssetResourceLocator.groovy
@@ -1,13 +1,15 @@
 package asset.pipeline.grails
 
+
 import asset.pipeline.AssetHelper
 import asset.pipeline.AssetPipelineConfigHolder
 import asset.pipeline.DirectiveProcessor
 import asset.pipeline.GenericAssetFile
+import groovy.util.logging.Slf4j
 import org.codehaus.groovy.grails.core.io.DefaultResourceLocator
 import org.springframework.core.io.ByteArrayResource
 import org.springframework.core.io.Resource
-import groovy.util.logging.Slf4j
+
 
 @Slf4j
 class AssetResourceLocator extends DefaultResourceLocator {

--- a/src/groovy/asset/pipeline/grails/AssetResourceLocator.groovy
+++ b/src/groovy/asset/pipeline/grails/AssetResourceLocator.groovy
@@ -40,14 +40,10 @@ class AssetResourceLocator extends DefaultResourceLocator {
 			}
 		} else {
 			List<String> contentTypes = AssetHelper.assetMimeTypeForURI(uri)
-			String contentType
-			if(contentTypes) {
-				contentType = contentTypes[0]
-			}
-
-			String    extension = AssetHelper.extensionFromURI(uri)
-			String    name      = AssetHelper.nameWithoutExtension(uri)
-			AssetFile assetFile = AssetHelper.fileForUri(name, contentType, extension)
+			String       contentType  = contentTypes ? contentTypes[0] : null
+			String       extension    = AssetHelper.extensionFromURI(uri)
+			String       name         = AssetHelper.nameWithoutExtension(uri)
+			AssetFile    assetFile    = AssetHelper.fileForUri(name, contentType, extension)
 			if(assetFile) {
 				if(assetFile instanceof GenericAssetFile) {
 					resource = new ByteArrayResource(assetFile.bytes)

--- a/src/groovy/asset/pipeline/grails/AssetResourceLocator.groovy
+++ b/src/groovy/asset/pipeline/grails/AssetResourceLocator.groovy
@@ -13,6 +13,7 @@ import org.springframework.core.io.Resource
 
 @Slf4j
 class AssetResourceLocator extends DefaultResourceLocator {
+
 	Resource findResourceForURI(String uri) {
 		Resource resource = super.findResourceForURI(uri)
 		if(!resource) {
@@ -42,9 +43,9 @@ class AssetResourceLocator extends DefaultResourceLocator {
 				contentType = contentTypes[0]
 			}
 
-			def extension    = AssetHelper.extensionFromURI(uri)
-			def name         = AssetHelper.nameWithoutExtension(uri)
-			def assetFile    = AssetHelper.fileForUri(name,contentType,extension)
+			def extension = AssetHelper.extensionFromURI(uri)
+			def name      = AssetHelper.nameWithoutExtension(uri)
+			def assetFile = AssetHelper.fileForUri(name, contentType, extension)
 			if(assetFile) {
 				if(assetFile instanceof GenericAssetFile) {
 					resource = new ByteArrayResource(assetFile.bytes)

--- a/src/groovy/asset/pipeline/grails/AssetResourceLocator.groovy
+++ b/src/groovy/asset/pipeline/grails/AssetResourceLocator.groovy
@@ -14,6 +14,7 @@ import org.springframework.core.io.Resource
 @Slf4j
 class AssetResourceLocator extends DefaultResourceLocator {
 
+	@Override
 	Resource findResourceForURI(String uri) {
 		Resource resource = super.findResourceForURI(uri)
 		if(!resource) {

--- a/src/groovy/asset/pipeline/grails/AssetResourceLocator.groovy
+++ b/src/groovy/asset/pipeline/grails/AssetResourceLocator.groovy
@@ -16,7 +16,7 @@ import org.springframework.core.io.Resource
 class AssetResourceLocator extends DefaultResourceLocator {
 
 	@Override
-	Resource findResourceForURI(String uri) {
+	Resource findResourceForURI(final String uri) {
 		Resource resource = super.findResourceForURI(uri)
 		if(!resource) {
 			resource = findAssetForURI(uri)
@@ -25,12 +25,12 @@ class AssetResourceLocator extends DefaultResourceLocator {
 	}
 
 	Resource findAssetForURI(String uri) {
-		Resource resource
+		final Resource resource
 		if(warDeployed) {
-			Properties manifest = AssetPipelineConfigHolder.manifest
+			final Properties manifest = AssetPipelineConfigHolder.manifest
 			uri = manifest?.getProperty(uri, uri)
 
-			String assetUri = "assets/${uri}"
+			final String assetUri = "assets/${uri}"
 			Resource defaultResource = defaultResourceLoader.getResource(assetUri)
 			if (!defaultResource?.exists()) {
 				defaultResource = defaultResourceLoader.getResource("classpath:${assetUri}")
@@ -39,18 +39,18 @@ class AssetResourceLocator extends DefaultResourceLocator {
 				resource = defaultResource
 			}
 		} else {
-			List<String> contentTypes = AssetHelper.assetMimeTypeForURI(uri)
-			String       contentType  = contentTypes ? contentTypes[0] : null
-			String       extension    = AssetHelper.extensionFromURI(uri)
-			String       name         = AssetHelper.nameWithoutExtension(uri)
-			AssetFile    assetFile    = AssetHelper.fileForUri(name, contentType, extension)
+			final List<String> contentTypes = AssetHelper.assetMimeTypeForURI(uri)
+			final String       contentType  = contentTypes ? contentTypes[0] : null
+			final String       extension    = AssetHelper.extensionFromURI(uri)
+			final String       name         = AssetHelper.nameWithoutExtension(uri)
+			final AssetFile    assetFile    = AssetHelper.fileForUri(name, contentType, extension)
 			if(assetFile) {
 				if(assetFile instanceof GenericAssetFile) {
 					resource = new ByteArrayResource(assetFile.bytes)
 				} else {
-					DirectiveProcessor directiveProcessor = new DirectiveProcessor(contentType, null, this.class.classLoader)
-					def fileContents = directiveProcessor.compile(assetFile)
-					String encoding = assetFile.encoding
+					final DirectiveProcessor directiveProcessor = new DirectiveProcessor(contentType, null, this.class.classLoader)
+					final def fileContents = directiveProcessor.compile(assetFile)
+					final String encoding = assetFile.encoding
 					if(encoding) {
 						resource = new ByteArrayResource(fileContents.getBytes(encoding))
 					} else {

--- a/src/groovy/asset/pipeline/grails/AssetResourceLocator.groovy
+++ b/src/groovy/asset/pipeline/grails/AssetResourceLocator.groovy
@@ -1,6 +1,7 @@
 package asset.pipeline.grails
 
 
+import asset.pipeline.AssetFile
 import asset.pipeline.AssetHelper
 import asset.pipeline.AssetPipelineConfigHolder
 import asset.pipeline.DirectiveProcessor
@@ -26,10 +27,10 @@ class AssetResourceLocator extends DefaultResourceLocator {
 	Resource findAssetForURI(String uri) {
 		Resource resource
 		if(warDeployed) {
-			def manifest = AssetPipelineConfigHolder.manifest
+			Properties manifest = AssetPipelineConfigHolder.manifest
 			uri = manifest?.getProperty(uri, uri)
 
-			def assetUri = "assets/${uri}"
+			String assetUri = "assets/${uri}"
 			Resource defaultResource = defaultResourceLoader.getResource(assetUri)
 			if (!defaultResource?.exists()) {
 				defaultResource = defaultResourceLoader.getResource("classpath:${assetUri}")
@@ -38,22 +39,22 @@ class AssetResourceLocator extends DefaultResourceLocator {
 				resource = defaultResource
 			}
 		} else {
-			def contentTypes = AssetHelper.assetMimeTypeForURI(uri)
-			def contentType
+			List<String> contentTypes = AssetHelper.assetMimeTypeForURI(uri)
+			String contentType
 			if(contentTypes) {
 				contentType = contentTypes[0]
 			}
 
-			def extension = AssetHelper.extensionFromURI(uri)
-			def name      = AssetHelper.nameWithoutExtension(uri)
-			def assetFile = AssetHelper.fileForUri(name, contentType, extension)
+			String    extension = AssetHelper.extensionFromURI(uri)
+			String    name      = AssetHelper.nameWithoutExtension(uri)
+			AssetFile assetFile = AssetHelper.fileForUri(name, contentType, extension)
 			if(assetFile) {
 				if(assetFile instanceof GenericAssetFile) {
 					resource = new ByteArrayResource(assetFile.bytes)
 				} else {
-					def directiveProcessor = new DirectiveProcessor(contentType, null, this.class.classLoader)
+					DirectiveProcessor directiveProcessor = new DirectiveProcessor(contentType, null, this.class.classLoader)
 					def fileContents = directiveProcessor.compile(assetFile)
-					def encoding = assetFile.encoding
+					String encoding = assetFile.encoding
 					if(encoding) {
 						resource = new ByteArrayResource(fileContents.getBytes(encoding))
 					} else {

--- a/src/java/asset/pipeline/grails/UrlBase.java
+++ b/src/java/asset/pipeline/grails/UrlBase.java
@@ -1,8 +1,0 @@
-package asset.pipeline.grails;
-
-
-public enum UrlBase {
-    SERVER_BASE_URL,
-    CONTEXT_PATH,
-    NONE
-}

--- a/test/unit/asset/pipeline/grails/AssetMethodTagLibSpec.groovy
+++ b/test/unit/asset/pipeline/grails/AssetMethodTagLibSpec.groovy
@@ -37,10 +37,8 @@ class AssetMethodTagLibSpec extends Specification {
 	def setup() {
 		AssetPipelineConfigHolder.registerResolver(new FileSystemAssetResolver('application','grails-app/assets'))
 
-		assetProcessorService.grailsApplication   = grailsApplication
-		assetProcessorService.grailsLinkGenerator = [serverBaseURL: MOCK_BASE_SERVER_URL]
-
 		tagLib.assetProcessorService = assetProcessorService
+		tagLib.grailsLinkGenerator   = [serverBaseURL: MOCK_BASE_SERVER_URL]
 	}
 
 	void "should return assetPath"() {

--- a/test/unit/asset/pipeline/grails/AssetsTagLibSpec.groovy
+++ b/test/unit/asset/pipeline/grails/AssetsTagLibSpec.groovy
@@ -38,13 +38,11 @@ class AssetsTagLibSpec extends Specification {
 	def setup() {
 		AssetPipelineConfigHolder.registerResolver(new FileSystemAssetResolver('application', 'grails-app/assets'))
 
-		assetProcessorService.grailsApplication   = grailsApplication
-		assetProcessorService.grailsLinkGenerator = [serverBaseURL: MOCK_BASE_SERVER_URL]
-
 		final def assetMethodTagLibMock = mockTagLib(AssetMethodTagLib)
 		assetMethodTagLibMock.assetProcessorService = assetProcessorService
+		assetMethodTagLibMock.grailsLinkGenerator   = [serverBaseURL: MOCK_BASE_SERVER_URL]
 
-		tagLib.assetProcessorService = assetProcessorService
+		tagLib.grailsApplication = grailsApplication
 	}
 
 	void "should return assetPath"() {


### PR DESCRIPTION
moved non-Grails instance methods from asset-pipeline-grails AssetProcessorService to static methods in new asset-pipeline-core AssetPaths

This is branched from the simple-cleanup PR, so please merge that first to isolate commits specific to this PR

Won't work until a new asset-pipeline-core version is released that includes bertramdev/asset-pipeline#97.  Must include that new version in grails-asset-pipeline, and then everything will compile.
