### PR TITLE
Fix #382 Asset Pipeline doesn't handle a missing file or src attribute in a g.resource taglib call

### DIFF
--- a/grails-app/services/asset/pipeline/grails/AssetProcessorService.groovy
+++ b/grails-app/services/asset/pipeline/grails/AssetProcessorService.groovy
@@ -52,6 +52,7 @@ class AssetProcessorService {
 
 
 	String getResolvedAssetPath(final String path, final ConfigObject conf = grailsApplication.config.grails.assets) {
+		if (!path) return null
 		final String relativePath = trimLeadingSlash(path)
 		if(manifest) {
 			manifest?.getProperty(relativePath)

--- a/grails-app/services/asset/pipeline/grails/AssetProcessorService.groovy
+++ b/grails-app/services/asset/pipeline/grails/AssetProcessorService.groovy
@@ -52,10 +52,9 @@ class AssetProcessorService {
 
 
 	String getResolvedAssetPath(final String path, final ConfigObject conf = grailsApplication.config.grails.assets) {
-		if (!path) return null
 		final String relativePath = trimLeadingSlash(path)
 		if(manifest) {
-			manifest?.getProperty(relativePath)
+			relativePath != null ? manifest?.getProperty(relativePath) : null
 		} else {
 			AssetHelper.fileForFullName(relativePath) != null ? relativePath : null
 		}


### PR DESCRIPTION
Since `AssetProcessorService.asset(attrs, linkGenerator)` and the overridden LinkGenerators handle null values, this is the only change required for g.resource calls to flow through to the default link generator.