### PR TITLE
Fix groovy.lang.MissingPropertyException: No such property: responseBuilder for class: asset.pipeline.grails.AssetPipelineFilter

### DIFF
--- a/src/groovy/asset/pipeline/grails/AssetPipelineFilter.groovy
+++ b/src/groovy/asset/pipeline/grails/AssetPipelineFilter.groovy
@@ -103,6 +103,9 @@ class AssetPipelineFilter implements Filter {
 				}
 
 				if(file.exists()) {
+					def fileLastModified = file.lastModified() ? new Date(file.lastModified()) : null
+					def responseBuilder = new AssetPipelineResponseBuilder(fileUri,request.getHeader('If-None-Match'), request.getHeader('If-Modified-Since'), fileLastModified)
+
 					responseBuilder.headers.each { header ->
 						response.setHeader(header.key,header.value)
 					}


### PR DESCRIPTION
Rollback change from c6a52f5 to restore the responseBuilder and fileLastModified variables.

Without this the run-war mode throws a `groovy.lang.MissingPropertyException: No such property: responseBuilder for class: asset.pipeline.grails.AssetPipelineFilter`